### PR TITLE
Scripts to render all icons in PNG, including those with symboles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,18 @@ Colors are from [Material Design Palette](https://materialuicolors.co/), and I u
 3. 200 for Border
 4. Black for Shadows
 
-# TODO - Bugs
-Small sizes are missing, so it doesn't look good with rest Adwaita folders, but at least work with largest size on Nautilus List view :)
+# Scripts
+*folders.svg* and *render-icon-theme.py* are copied from [GNOME Adwaita icon theme](https://gitlab.gnome.org/GNOME/adwaita-icon-theme)
+
+*gen-color-folders.sh* can be use to generate new *folders.svg* with the 20 additional colors. The files are created under *src/fullcolor* and the directory will be created from the the active directory if it doesn't already exists.
+```
+./gen-color-folders.sh
+```
+Then, use *render-icon-theme.py* to render all PNG icons (it takes a while):
+```
+./render-icon-theme.py
+```
+You can also render only one color:
+```
+./render-icon-theme.py folders-amber
+```

--- a/folders.svg
+++ b/folders.svg
@@ -1,0 +1,3378 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="96"
+   inkscape:export-xdpi="96"
+   inkscape:export-filename="/home/sam/Temp/folders.png"
+   width="7056"
+   height="1152"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="folders.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   viewBox="0 0 7056 1152">
+  <title
+     id="title4162">Adwaita Folder Icons</title>
+  <defs
+     id="defs3">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient21057">
+      <stop
+         style="stop-color:#1a5fb4;stop-opacity:1"
+         offset="0"
+         id="stop21053" />
+      <stop
+         style="stop-color:#8ca0b8;stop-opacity:1"
+         offset="1"
+         id="stop21055" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5116">
+      <stop
+         style="stop-color:#77767b;stop-opacity:0"
+         offset="0"
+         id="stop5112" />
+      <stop
+         id="stop5122"
+         offset="0.12760141"
+         style="stop-color:#77767b;stop-opacity:1" />
+      <stop
+         id="stop5120"
+         offset="0.83094698"
+         style="stop-color:#77767b;stop-opacity:1" />
+      <stop
+         style="stop-color:#77767b;stop-opacity:0"
+         offset="1"
+         id="stop5114" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5028"
+       inkscape:collect="always">
+      <stop
+         id="stop5024"
+         offset="0"
+         style="stop-color:#77767b;stop-opacity:1" />
+      <stop
+         id="stop5026"
+         offset="1"
+         style="stop-color:#aeadab;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1725"
+       inkscape:collect="always">
+      <stop
+         id="stop1717"
+         offset="0"
+         style="stop-color:#9a9996;stop-opacity:0" />
+      <stop
+         style="stop-color:#9a9996;stop-opacity:1"
+         offset="0.09090909"
+         id="stop1719" />
+      <stop
+         style="stop-color:#9a9996;stop-opacity:1"
+         offset="0.90909094"
+         id="stop1721" />
+      <stop
+         id="stop1723"
+         offset="1"
+         style="stop-color:#9a9996;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1693">
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0"
+         id="stop1689" />
+      <stop
+         id="stop1697"
+         offset="0.05454545"
+         style="stop-color:#000000;stop-opacity:0.94509804;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.93181819"
+         id="stop1699" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop1691" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1835"
+       x="-0.011571429"
+       width="1.0231429"
+       y="-0.012461538"
+       height="1.0249231">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.16"
+         id="feGaussianBlur1837" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1725"
+       id="linearGradient1660"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(10.212766,0,0,8.0000001,-11588.426,5504)"
+       x1="1202"
+       y1="-735"
+       x2="1246"
+       y2="-735" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1693"
+       id="linearGradient1695"
+       x1="704"
+       y1="-356"
+       x2="1144"
+       y2="-356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1705"
+       x="-0.0078"
+       width="1.0156"
+       y="-0.026"
+       height="1.052">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.56"
+         id="feGaussianBlur1707" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5028"
+       id="linearGradient5022"
+       x1="904"
+       y1="-340"
+       x2="904"
+       y2="-372"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5028"
+       id="linearGradient5030"
+       gradientUnits="userSpaceOnUse"
+       x1="1224.25"
+       y1="-741.9375"
+       x2="1224.25"
+       y2="-744.3465" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5028"
+       id="linearGradient5074"
+       gradientUnits="userSpaceOnUse"
+       x1="1216"
+       y1="-677.5"
+       x2="1216"
+       y2="-680.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1725"
+       id="linearGradient5106"
+       x1="1201"
+       y1="-744"
+       x2="1247"
+       y2="-744"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5116"
+       id="linearGradient5118"
+       x1="1247.5"
+       y1="-745.5"
+       x2="1200.5"
+       y2="-745.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1725"
+       id="linearGradient5164"
+       gradientUnits="userSpaceOnUse"
+       x1="1199.5"
+       y1="-678.5"
+       x2="1232.5"
+       y2="-678.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5116"
+       id="linearGradient5168"
+       gradientUnits="userSpaceOnUse"
+       x1="1232.3232"
+       y1="-680.53296"
+       x2="1199.5277"
+       y2="-680.53296" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1725"
+       id="linearGradient5210"
+       gradientUnits="userSpaceOnUse"
+       x1="1200.5"
+       y1="-629.5"
+       x2="1223.5"
+       y2="-629.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5116"
+       id="linearGradient5212"
+       gradientUnits="userSpaceOnUse"
+       x1="1223.5"
+       y1="-631.5"
+       x2="1200.5"
+       y2="-631.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1725"
+       id="linearGradient5254"
+       gradientUnits="userSpaceOnUse"
+       x1="1200"
+       y1="-589"
+       x2="1216"
+       y2="-589" />
+    <linearGradient
+       gradientTransform="translate(-704,788)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient21057"
+       id="linearGradient21059-4"
+       x1="802"
+       y1="-745"
+       x2="802"
+       y2="-666"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(-64,-672)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient21057"
+       id="linearGradient21152-9"
+       gradientUnits="userSpaceOnUse"
+       x1="158"
+       y1="715"
+       x2="158"
+       y2="791" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1302"
+       x="-0.012000846"
+       width="1.0240017"
+       y="-0.011999154"
+       height="1.0239983">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.0803224"
+         id="feGaussianBlur1304" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1306"
+       x="-0.011308596"
+       width="1.0226172"
+       y="-0.012781454"
+       height="1.0255629">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.9603225"
+         id="feGaussianBlur1308" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1316"
+       x="-0.013329623"
+       width="1.0266592"
+       y="-0.12030141"
+       height="1.2406028">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.3104787"
+         id="feGaussianBlur1318" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1509">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path1511"
+         d="M 192,-164 H 88 c 0,0 -40,0 -40,40 V 4 h 416 v -96 c 0,0 0,-40 -40,-40 H 224 Z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1529"
+       x="-0.10846154"
+       width="1.2169231"
+       y="-0.13428571"
+       height="1.2685714">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="18.8"
+         id="feGaussianBlur1531" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1509-7">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path1511-5"
+         d="M 192,-164 H 88 c 0,0 -40,0 -40,40 V 4 h 416 v -96 c 0,0 0,-40 -40,-40 H 224 Z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1529-3"
+       x="-0.10846154"
+       width="1.2169231"
+       y="-0.1342857"
+       height="1.2685714">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="18.8"
+         id="feGaussianBlur1531-5" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="1138.4313"
+     inkscape:cy="479.40173"
+     inkscape:current-layer="g8460"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     objecttolerance="7"
+     gridtolerance="12"
+     guidetolerance="13"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="false"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:locked="false"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0"
+     inkscape:object-nodes="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:bbox-paths="true"
+     inkscape:snap-others="false"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-page="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5883"
+       spacingx="1"
+       spacingy="1"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       originx="0"
+       originy="0" />
+    <sodipodi:guide
+       position="1200,144"
+       orientation="0,1"
+       id="guide8350"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1216,458"
+       orientation="0,1"
+       id="guide6031"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="912,272"
+       orientation="1,0"
+       id="guide6188"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1856,1050"
+       orientation="0,1"
+       id="guide6707"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1848.3771,753.77583"
+       orientation="0,1"
+       id="guide6744"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1784,644"
+       orientation="0,1"
+       id="guide8527"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="63.927857,63.8761"
+       orientation="0,1"
+       id="guide8529"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1865.3477,878.22662"
+       orientation="0,1"
+       id="guide10362"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="592,304"
+       orientation="0,1"
+       id="guide6119"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1216,474"
+       orientation="0,1"
+       id="guide5628"
+       inkscape:locked="false" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid1471"
+       empspacing="4"
+       dotted="true"
+       spacingx="0.5"
+       spacingy="0.5" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Lapo Calamandrei</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Adwaita Folder Icons</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Sam Hewitt, Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:folder (Clone source)"
+     id="g11609">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g11523"
+       inkscape:groupmode="layer"
+       sodipodi:insensitive="true">
+      <g
+         transform="translate(50,75)"
+         id="g11487">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect11483"
+           width="512"
+           height="512"
+           x="-34"
+           y="-303"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path11485"
+           d="M -34,-303 V 209 H 478 V -303 H 441.99121 V 173 H 2.0087912 v -476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11489"
+         width="48"
+         height="48"
+         x="560"
+         y="-196"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-116"
+         x="560"
+         height="32"
+         width="32"
+         id="rect11491"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11493"
+         width="22"
+         height="22"
+         x="561"
+         y="-58.941162"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-12"
+         x="560"
+         height="16"
+         width="16"
+         id="rect11495"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-60"
+         x="560"
+         height="24"
+         width="24"
+         id="rect11497"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text11501"
+         y="-271.69958"
+         x="23.855942"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-271.69958"
+           x="23.855942"
+           id="tspan11499"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="103.26477"
+         y="-271.90063"
+         id="text11505"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           id="tspan11503"
+           x="103.26477"
+           y="-271.90063"
+           style="font-size:14.66666698px;line-height:1.25">folder</tspan></text>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g11607"
+       inkscape:groupmode="layer">
+      <g
+         id="g11603">
+        <g
+           transform="matrix(4,0,0,4,16.000006,-6796)"
+           style="display:inline;enable-background:new"
+           id="folder"
+           inkscape:label="#g3169">
+          <title
+             id="title4404">folder</title>
+          <rect
+             y="1642"
+             x="-1.5000001e-06"
+             height="128"
+             width="128"
+             id="rect9125"
+             style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
+          <g
+             transform="matrix(0.25,0,0,0.25,-1.5e-6,1695)"
+             id="g6962">
+            <path
+               id="path1310"
+               d="m 464,210 c 0,0 0,40 -40,40 l -375.998047,0.0938 -0.0039,6 L 424,256 c 40,0 40,-40 40,-40 z"
+               style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter1316);enable-background:new"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path1461"
+               d="m 88,-162 c 0,0 -40,0 -40,40 L 47.964844,6 h 0.0332 L 47.964844,254.0938 424,254 c 40,0 40,-40 40,-40 V 6 -42 -90 c 0,0 0,-40 -40,-40 H 224 l -32,-32 z"
+               style="display:inline;opacity:0.2;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter1302);enable-background:new" />
+            <path
+               style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+               d="M 208,672 H 104 c 0,0 -40,0 -40,40 v 128 h 416 v -96 c 0,0 0,-40 -40,-40 H 240 Z"
+               transform="translate(-16,-836)"
+               id="path1442"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccccccc" />
+            <path
+               id="path1505"
+               d="m 256,-80 -32,32 H 88 c 0,0 -40,0 -40,40 v 264 h 376 c 40,0 40,-40 40,-40 V -40 c 0,-40 -40,-40 -40,-40 z"
+               style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter1529);enable-background:new"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccccccccc"
+               clip-path="url(#clipPath1509)" />
+            <path
+               sodipodi:nodetypes="cccccccccc"
+               inkscape:connector-curvature="0"
+               style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+               d="m 256,-84 -32,32 H 88 c 0,0 -40,0 -40,40 v 264 h 376 c 40,0 40,-40 40,-40 V -44 c 0,-40 -40,-40 -40,-40 z"
+               id="rect1100-0-9" />
+            <path
+               style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+               d="m 480,1042 c 0,0 0,40 -40,40 l -375.998047,0.094 -0.0039,6 L 440,1088 c 40,0 40,-40 40,-40 z"
+               transform="translate(-16,-836)"
+               id="path1449"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+               d="m 272,752 -32,32 H 104 c 0,0 -40,0 -40,40 v 4 c 0,-40 40,-40 40,-40 h 137.59099 l 32,-32 H 440 c 0,0 40,0 40,40 v -4 c 0,-40 -40,-40 -40,-40 z"
+               id="path1328"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccsccccccscc"
+               transform="translate(-16,-836)" />
+          </g>
+        </g>
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           d="m 566,658.5 c 0,0 -3.5,0 -3.5,3.5 v 18.5 h 43 V 666 c 0,0 0,-3.5 -3.5,-3.5 h -20.5 l -4,-4 z"
+           id="rect1100-6-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cscccsccc"
+           transform="translate(0,-852)" />
+        <path
+           id="path2552"
+           d="m 566,-180.5 c 0,0 -3.5,0 -3.5,3.5 v 26.5 H 601 c 0,0 4.5,0 4.5,-4.5 v -26 c 0,0 0,-3.5 -3.5,-3.5 h -18.5 l -4,4 z"
+           style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           id="path5595"
+           d="m 565,-113.5 c 0,0 -2.5,0 -2.5,2.5 v 16.5 H 587 c 2.5,0 2.5,-2.5 2.5,-2.5 v -11 c 0,0 0,-2.5 -2.5,-2.5 h -12.5 l -3,-3 z"
+           style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           d="m 563.5,793.5 c -2,0 -2,2 -2,2 v 11 h 21 v -9 c 0,0 0,-2 -2,-2 h -10 l -2,-2 z"
+           transform="translate(0,-852)"
+           id="path5599"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccsccs" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           d="m 562,840.5 c 0,0 -1.50195,-0.0312 -1.50195,1.46875 V 848.5 H 575.5 V 844 c 0,-1.5 -1.5,-1.5 -1.5,-1.5 h -5.5 l -2,-2 z"
+           transform="translate(0,-852)"
+           id="path5603"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path2536"
+           d="m 563.5,-51.5 c -2,0 -2,2 -2,2 v 12 H 580 c 2.5,0 2.5,-2.5 2.5,-2.5 v -11.5 c 0,0 0,-2 -2,-2 H 572 l -2,2 z"
+           style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           sodipodi:nodetypes="ccccccccccc"
+           inkscape:connector-curvature="0"
+           style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           d="m 573.99902,-8.5 c 0,0 1.501,-0.03072 1.501,1.469276 L 575.5,2 c 0,1.5 -1.5,1.5 -1.5,1.5 h -13.5 v 0 l -9.8e-4,-8.5 c 0,-1.5 1.5,-1.5 1.5,-1.5 h 3.5 l 2,-2 z"
+           id="path2538" />
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           d="m 565,-105.5 c 0,0 -2.5,0 -2.5,2.5 v 16.5 H 587 c 2.5,0 2.5,-2.5 2.5,-2.5 v -16 c 0,0 0,-2.5 -2.5,-2.5 h -11.5 l -2,2 z"
+           id="path2546" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g8488"
+     inkscape:label="artwork:folder-documents"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g8456"
+       inkscape:label="baseplate"
+       style="display:none">
+      <rect
+         inkscape:label="48x48"
+         y="-196"
+         x="1200"
+         height="48"
+         width="48"
+         id="rect8434"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect8436"
+         width="32"
+         height="32"
+         x="1200"
+         y="-116"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-58.941162"
+         x="1201"
+         height="22"
+         width="22"
+         id="rect8438"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect8440"
+         width="16"
+         height="16"
+         x="1200"
+         y="-12"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect8442"
+         width="24"
+         height="24"
+         x="1200"
+         y="-60"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="686.94397"
+         y="-279.63733"
+         id="text8446"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan8444"
+           x="686.94397"
+           y="-279.63733"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text8450"
+         y="-279.83838"
+         x="766.35278"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.83838"
+           x="766.35278"
+           id="tspan8448"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">folder-documents</tspan></text>
+      <g
+         id="g10368"
+         style="display:inline;enable-background:new"
+         transform="translate(640)">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect10364"
+           width="512"
+           height="512"
+           x="16"
+           y="-228"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path10366"
+           d="M 16,-228 V 284 H 528 V -228 H 491.99121 V 248 H 52.008791 v -476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g8460"
+       inkscape:label="icons"
+       style="display:inline">
+      <use
+         height="100%"
+         width="100%"
+         transform="translate(639.9999)"
+         id="use5377"
+         xlink:href="#g11603"
+         y="0"
+         x="0"
+         style="display:inline;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-opacity:1;enable-background:new" />
+    </g>
+    <g
+       inkscape:label="symbols"
+       id="g8486"
+       inkscape:groupmode="layer"
+       style="display:inline">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 856,848 a 8.0008,8.0008 0 0 0 -8,8 v 144 a 8.0008,8.0008 0 0 0 8,8 h 112 a 8.0008,8.0008 0 0 0 8,-8 V 891 a 8.0008,8.0008 0 0 0 -2.42383,-5.73633 l -36,-35 A 8.0008,8.0008 0 0 0 932,848 Z m 8,16 h 64 v 32 h 32 v 96 h -96 z"
+         id="path1696"
+         transform="translate(0,-852)"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 1218,678 a 1.0001,1.0001 0 0 0 -1,1 v 15 a 1.0001,1.0001 0 0 0 1,1 h 12 a 1.0001,1.0001 0 0 0 1,-1 v -11.5 a 1.0001,1.0001 0 0 0 -0.293,-0.70703 l -3.5,-3.5 A 1.0001,1.0001 0 0 0 1226.5,678 Z m 1,2 h 7 v 3 h 3 v 10 h -10 z"
+         transform="translate(0,-852)"
+         id="path13499"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 1209.5,804 a 0.50005,0.50005 0 0 0 -0.5,0.5 v 7 a 0.50005,0.50005 0 0 0 0.5,0.5 h 5 a 0.50005,0.50005 0 0 0 0.5,-0.5 V 806 a 0.50005,0.50005 0 0 0 -0.1465,-0.35352 l -1.5,-1.5 A 0.50005,0.50005 0 0 0 1213,804 Z m 0.5,1 h 2 v 2 h 2 v 4 h -4 z"
+         transform="translate(0,-852)"
+         id="path1672"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 1205.5,847 a 0.50005,0.50005 0 0 0 -0.5,0.5 v 6 a 0.50005,0.50005 0 0 0 0.5,0.5 h 5 a 0.50005,0.50005 0 0 0 0.5,-0.5 V 849 a 0.50005,0.50005 0 0 0 -0.1465,-0.35352 l -1.5,-1.5 A 0.50005,0.50005 0 0 0 1209,847 Z m 0.5,1 h 2 v 2 h 2 v 3 h -4 z"
+         transform="translate(0,-852)"
+         id="path1678"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 1212,750 a 1.0001,1.0001 0 0 0 -1,1 v 10 a 1.0001,1.0001 0 0 0 1,1 h 8 a 1.0001,1.0001 0 0 0 1,-1 v -7 a 1.0001,1.0001 0 0 0 -0.293,-0.70703 l -3,-3 A 1.0001,1.0001 0 0 0 1217,750 Z m 1,2 h 3 v 3 h 3 v 5 h -6 z"
+         transform="translate(0,-852)"
+         id="path1684"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:inode-directory"
+     id="g1345">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g1327"
+       inkscape:groupmode="layer">
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect1303"
+         width="48"
+         height="48"
+         x="560"
+         y="-776"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-696"
+         x="560"
+         height="32"
+         width="32"
+         id="rect1305"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect1307"
+         width="22"
+         height="22"
+         x="561"
+         y="-638.94116"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-592"
+         x="560"
+         height="16"
+         width="16"
+         id="rect1309"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-640"
+         x="560"
+         height="24"
+         width="24"
+         id="rect1311"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text1315"
+         y="-859.63733"
+         x="46.94397"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           style="font-size:14.66666698px;line-height:1.25"
+           y="-859.63733"
+           x="46.94397"
+           id="tspan1313"
+           sodipodi:role="line">mimetypes</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="126.35278"
+         y="-859.83838"
+         id="text1319"
+         inkscape:label="icon-name"><tspan
+           style="font-size:14.66666698px;line-height:1.25"
+           sodipodi:role="line"
+           id="tspan1317"
+           x="126.35278"
+           y="-859.83838">inode-directory</tspan></text>
+      <g
+         transform="translate(0,-580)"
+         style="display:inline;enable-background:new"
+         id="g1325">
+        <rect
+           inkscape:label="512x512"
+           y="-228"
+           x="16"
+           height="512"
+           width="512"
+           id="rect1321"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="M 16,-228 V 284 H 528 V -228 H 491.99121 V 248 H 52.008791 v -476 z"
+           id="path1323"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g1331"
+       inkscape:groupmode="layer">
+      <use
+         style="display:inline;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-opacity:1;enable-background:new"
+         x="0"
+         y="0"
+         xlink:href="#g11603"
+         id="use1329"
+         transform="translate(-10e-5,-580)"
+         width="100%"
+         height="100%" />
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:folder-download"
+     id="g10950">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g10918"
+       inkscape:groupmode="layer">
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect10894"
+         width="48"
+         height="48"
+         x="1840"
+         y="-196"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-116"
+         x="1840"
+         height="32"
+         width="32"
+         id="rect10896"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect10898"
+         width="22"
+         height="22"
+         x="1841"
+         y="-58.941162"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-12"
+         x="1840"
+         height="16"
+         width="16"
+         id="rect10900"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-60"
+         x="1840"
+         height="24"
+         width="24"
+         id="rect10902"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text10906"
+         y="-279.63733"
+         x="1326.944"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.63733"
+           x="1326.944"
+           id="tspan10904"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="1406.3528"
+         y="-279.83838"
+         id="text10910"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           x="1406.3528"
+           y="-279.83838"
+           id="tspan11152"
+           style="font-size:14.66666698px;line-height:1.25">folder-download</tspan></text>
+      <g
+         transform="translate(1280)"
+         style="display:inline;enable-background:new"
+         id="g10916">
+        <rect
+           inkscape:label="512x512"
+           y="-228"
+           x="16"
+           height="512"
+           width="512"
+           id="rect10912"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="M 16,-228 V 284 H 528 V -228 H 491.99121 V 248 H 52.008791 v -476 z"
+           id="path10914"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g10922"
+       inkscape:groupmode="layer">
+      <use
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1"
+         x="0"
+         y="0"
+         xlink:href="#g11603"
+         id="use5383"
+         transform="translate(1279.9999)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g10948"
+       inkscape:label="symbols"
+       style="display:inline">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 1847.9164,-3.9999988 -0.01,3.03576112 -0.6637,-0.66342902 c -0.1115,-0.111522 -0.2688,-0.1667101 -0.4258,-0.1667101 h -0.5927 v 0.5926409 c 0,0.1572044 0.055,0.31441941 0.1666,0.42596303 l 1.7733,1.77577286 0.6829,-0.0180926 1.7552,-1.75768111 c 0.1116,-0.11154386 0.1664,-0.26875878 0.1664,-0.42596338 v -0.5926407 h -0.5925 c -0.157,0 -0.3145,0.055133 -0.4259,0.1667099 l -0.6821,0.68192509 L 1849.0591,-4 Z"
+         id="path8676"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccc" />
+      <path
+         id="path13341"
+         d="m 1863.0157,-174.00503 v 12.08594 l -2.793,-2.79297 c -0.1875,-0.18753 -0.4418,-0.29291 -0.707,-0.29297 h -0.5 -1 v 1 c 10e-5,0.2652 0.1055,0.51952 0.293,0.70703 l 5,5 c 0.3905,0.39033 1.0235,0.39033 1.414,0 l 5,-5 c 0.1875,-0.18751 0.2929,-0.44183 0.293,-0.70703 v -0.0156 -0.98437 h -1 -0.5 c -0.2652,6e-5 -0.5195,0.10544 -0.707,0.29297 l -2.793,2.79297 V -174.005 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 1855,-102 v 7.5 l -2.293,-2.20703 C 1852.5195,-96.894559 1852.2652,-96.99994 1852,-97 h -0.5 -0.5 v 1 c 10e-5,0.265203 0.1055,0.519524 0.293,0.70703 l 4.0157,3.99497 c 0.3905,0.390327 1.0235,0.390327 1.414,0 l 3.9843,-3.995 c 0.1875,-0.187506 0.2929,-0.441827 0.293,-0.70703 V -96.01563 -97 h -0.5 -0.5 c -0.2652,6e-5 -0.5195,0.105441 -0.707,0.29297 l -2.293,2.20706 v -7.5 z"
+         id="path2841"
+         sodipodi:nodetypes="cccccccccccccccccccc" />
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccc"
+         id="path2843"
+         d="m 1851,-49 v 5.5 l -1.293,-1.20703 C 1849.5195,-44.894559 1849.2652,-44.99994 1849,-45 h -0.5 -0.5 v 1 c 10e-5,0.265203 0.1055,0.519524 0.293,0.70703 l 3.0157,2.99497 c 0.3905,0.390327 1.0235,0.390327 1.414,0 l 2.9843,-2.995 c 0.1875,-0.187506 0.2929,-0.441827 0.293,-0.70703 V -44.01563 -45 h -0.5 -0.5 c -0.2652,6e-5 -0.5195,0.105441 -0.707,0.29297 l -1.293,1.20706 v -5.5 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="M 1536 848 L 1536 986.57812 L 1535.9922 986.56836 C 1535.9624 987.45987 1535.3673 987.77855 1534.7715 987.45898 L 1493.6562 946.34375 C 1492.1562 944.84352 1490.1215 944.00048 1488 944 L 1484 944 L 1480 944 L 1480 952 C 1480.0005 954.12162 1480.8434 956.1562 1482.3438 957.65625 L 1538.3438 1013.6562 C 1541.4679 1016.7789 1546.532 1016.7789 1549.6562 1013.6562 L 1605.6562 957.65625 C 1607.1566 956.1562 1607.9995 954.12162 1608 952 C 1608.0003 951.9584 1608.0003 951.9166 1608 951.875 L 1608 944 L 1604 944 L 1600 944 C 1597.8785 944.00048 1595.8437 944.84352 1594.3438 946.34375 L 1553.334 987.35352 C 1552.7137 987.74456 1552.0681 987.43162 1552.0371 986.50195 L 1552 986.54883 L 1552 848 L 1536 848 z "
+         id="path2845"
+         transform="translate(0,-852)" />
+    </g>
+  </g>
+  <g
+     id="g6289"
+     inkscape:label="artwork:folder-saved-serch"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g6261"
+       inkscape:label="baseplate"
+       style="display:none">
+      <rect
+         inkscape:label="48x48"
+         y="-796"
+         x="1840"
+         height="48"
+         width="48"
+         id="rect6236"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6239"
+         width="32"
+         height="32"
+         x="1840"
+         y="-716"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-658.94116"
+         x="1841"
+         height="22"
+         width="22"
+         id="rect6241"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6243"
+         width="16"
+         height="16"
+         x="1840"
+         y="-612"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6245"
+         width="24"
+         height="24"
+         x="1840"
+         y="-660"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="1326.944"
+         y="-879.63733"
+         id="text6249"
+         inkscape:label="context"><tspan
+           style="font-size:14.66666698px;line-height:1.25"
+           sodipodi:role="line"
+           id="tspan6247"
+           x="1326.944"
+           y="-879.63733">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text6253"
+         y="-879.83838"
+         x="1406.3528"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           style="font-size:14.66666698px;line-height:1.25"
+           id="tspan6251"
+           y="-879.83838"
+           x="1406.3528"
+           sodipodi:role="line">folder-saved-search</tspan></text>
+      <g
+         id="g6259"
+         style="display:inline;enable-background:new"
+         transform="translate(1280,-600)">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect6255"
+           width="512"
+           height="512"
+           x="16"
+           y="-228"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6257"
+           d="M 16,-228 V 284 H 528 V -228 H 491.99121 V 248 H 52.008791 v -476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g6267"
+       inkscape:label="icons"
+       style="display:inline">
+      <use
+         height="100%"
+         width="100%"
+         transform="translate(1279.9999,-600)"
+         id="use6263"
+         xlink:href="#g11603"
+         y="0"
+         x="0"
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1" />
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="symbols"
+       id="g6287"
+       inkscape:groupmode="layer">
+      <g
+         transform="matrix(1.1460375,0,0,1.1460375,1694.3296,-1515.4869)"
+         inkscape:label="edit-find"
+         id="g2204-5"
+         style="display:inline;stroke-width:8.72571659;enable-background:new;fill:#b5835a;fill-opacity:1" />
+      <g
+         style="display:inline;stroke-width:17.51750565;enable-background:new;fill:#b5835a;fill-opacity:1"
+         id="g9010"
+         inkscape:label="edit-find"
+         transform="matrix(0.57085744,0,0,0.57085744,1763.5039,-975.3451)" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;marker:none;enable-background:new;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 1847.7187,-605 c -1.4956,0 -2.7187,1.22315 -2.7187,2.71875 0,1.4956 1.2231,2.71875 2.7187,2.71875 0.4871,0 0.9473,-0.14835 1.3438,-0.375 0.039,0.0817 0.091,0.15583 0.1562,0.21875 l 1.8438,1.8125 c 0.7083,0.7085 1.7708,-0.354 1.0625,-1.0625 l -1.8438,-1.8125 c -0.063,-0.0648 -0.137,-0.11776 -0.2187,-0.15625 0.2266,-0.39646 0.375,-0.85664 0.375,-1.34375 0,-1.4956 -1.2232,-2.71875 -2.7188,-2.71875 z m 0,1 c 0.9552,0 1.7188,0.76359 1.7188,1.71875 0,0.95516 -0.7636,1.71875 -1.7188,1.71875 -0.9552,0 -1.7187,-0.76359 -1.7187,-1.71875 0,-0.95516 0.7635,-1.71875 1.7187,-1.71875 z"
+         id="path27332"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssccccccsssssss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 1862.5,-775 c -3.578,0 -6.5,2.92199 -6.5,6.5 0,3.57801 2.922,6.5 6.5,6.5 3.578,0 6.5,-2.92199 6.5,-6.5 0,-3.57801 -2.922,-6.5 -6.5,-6.5 z m 0,2 c 2.4971,0 4.5,2.00287 4.5,4.5 0,2.49713 -2.0029,4.5 -4.5,4.5 -2.4971,0 -4.5,-2.00287 -4.5,-4.5 0,-2.49713 2.0029,-4.5 4.5,-4.5 z"
+         id="path2859"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 1866.4902,-765.50977 a 1.0001,1.0001 0 0 0 -0.6972,1.7168 l 4.5,4.5 a 1.0001,1.0001 0 1 0 1.414,-1.41406 l -4.5,-4.5 a 1.0001,1.0001 0 0 0 -0.7168,-0.30274 z"
+         id="path2861"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="m 1851,-649 c -1.6509,0 -3,1.34906 -3,3 0,1.65094 1.3491,3 3,3 1.6509,0 3,-1.34906 3,-3 0,-1.65094 -1.3491,-3 -3,-3 z m 0,1 c 1.1108,0 2,0.88916 2,2 0,1.11084 -0.8892,2 -2,2 -1.1108,0 -2,-0.88916 -2,-2 0,-1.11084 0.8892,-2 2,-2 z"
+         id="circle2867"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="m 1852.9961,-644.50391 a 0.49973454,0.49973454 0 0 0 -0.3496,0.85743 l 2.4941,2.5039 a 0.4999547,0.4999547 0 1 0 0.709,-0.70508 l -2.4961,-2.50586 a 0.49973454,0.49973454 0 0 0 -0.3574,-0.15039 z"
+         id="path2869"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 1855,-702 c -2.2003,0 -4,1.79974 -4,4 0,2.20026 1.7997,4 4,4 2.2003,0 4,-1.79974 4,-4 0,-2.20026 -1.7997,-4 -4,-4 z m 0,1.5 c 1.3896,0 2.5,1.1104 2.5,2.5 0,1.3896 -1.1104,2.5 -2.5,2.5 -1.3896,0 -2.5,-1.1104 -2.5,-2.5 0,-1.3896 1.1104,-2.5 2.5,-2.5 z"
+         id="circle2873"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 1857.4922,-696.25781 a 0.750075,0.750075 0 0 0 -0.5234,1.28711 l 3,3 a 0.750075,0.750075 0 1 0 1.0624,-1.0586 l -3,-3.00195 a 0.750075,0.750075 0 0 0 -0.539,-0.22656 z"
+         id="path2875"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="M 1536 256.21484 C 1500.7485 256.21484 1472 284.96338 1472 320.21484 C 1472 355.46631 1500.7485 384.21484 1536 384.21484 C 1550.8075 384.21484 1564.4564 379.12911 1575.3203 370.63281 L 1618.3438 413.65625 A 8.0008 8.0008 0 1 0 1629.6562 402.34375 L 1586.6074 359.29492 C 1594.9905 348.4704 1600 334.91279 1600 320.21484 C 1600 284.96338 1571.2515 256.21484 1536 256.21484 z M 1536 272.21484 C 1562.6044 272.21484 1584 293.61042 1584 320.21484 C 1584 346.81927 1562.6044 368.21484 1536 368.21484 C 1509.3956 368.21484 1488 346.81927 1488 320.21484 C 1488 293.61042 1509.3956 272.21484 1536 272.21484 z "
+         id="circle2891"
+         transform="translate(0,-852)" />
+    </g>
+  </g>
+  <g
+     id="g11208"
+     inkscape:label="artwork:folder-music"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g11180"
+       inkscape:label="baseplate"
+       style="display:none">
+      <rect
+         inkscape:label="48x48"
+         y="-196"
+         x="2480"
+         height="48"
+         width="48"
+         id="rect11156"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11158"
+         width="32"
+         height="32"
+         x="2480"
+         y="-116"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-58.941162"
+         x="2481"
+         height="22"
+         width="22"
+         id="rect11160"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11162"
+         width="16"
+         height="16"
+         x="2480"
+         y="-12"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11164"
+         width="24"
+         height="24"
+         x="2480"
+         y="-60"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="1966.9438"
+         y="-279.63733"
+         id="text11168"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan11166"
+           x="1966.9438"
+           y="-279.63733"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text11172"
+         y="-279.83838"
+         x="2046.3528"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           id="tspan11170"
+           y="-279.83838"
+           x="2046.3528"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">folder-music</tspan></text>
+      <g
+         id="g11178"
+         style="display:inline;enable-background:new"
+         transform="translate(1920,0)">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect11174"
+           width="512"
+           height="512"
+           x="16"
+           y="-228"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path11176"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g11184"
+       inkscape:label="icons"
+       style="display:inline">
+      <use
+         height="100%"
+         width="100%"
+         transform="translate(1919.9999)"
+         id="use5389"
+         xlink:href="#g11603"
+         y="0"
+         x="0"
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1" />
+    </g>
+    <g
+       inkscape:label="symbols"
+       id="g11206"
+       inkscape:groupmode="layer"
+       style="display:inline">
+      <path
+         style="display:inline;opacity:1;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;paint-order:normal"
+         d="m 2491.5,-49.000003 c -0.277,0 -0.5,0.223 -0.5,0.5 v 0.5 3.27148 c -0.3037,-0.17677 -0.6486,-0.27041 -1,-0.27148 -1.1046,0 -2,0.89543 -2,2 0,1.10457 0.8954,2 2,2 1.1046,0 2,-0.89543 2,-2 v -5 h 4 v 3.27148 c -0.3037,-0.17677 -0.6486,-0.27041 -1,-0.27148 -1.1046,0 -2,0.89543 -2,2 0,1.10457 0.8954,2 2,2 1.1046,0 2,-0.89543 2,-2 v -5 -0.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z m -1.5,5 c 0.5523,0 1,0.44772 1,1 0,0.55228 -0.4477,1 -1,1 -0.5523,0 -1,-0.44772 -1,-1 0,-0.55228 0.4477,-1 1,-1 z m 5,0 c 0.5523,0 1,0.44772 1,1 0,0.55228 -0.4477,1 -1,1 -0.5523,0 -1,-0.44772 -1,-1 0,-0.55228 0.4477,-1 1,-1 z"
+         id="path11294"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscccsssccccssscsssssssssssss" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path11325"
+         d="m 2487.5,-5 c -0.277,0 -0.5,0.223 -0.5,0.5 v 0.5 2.27148 c -0.3037,-0.176771 -0.6486,-0.2704071 -1,-0.27148 -1.1046,0 -2,0.8954305 -2,2 0,1.1045695 0.8954,2 2,2 1.1046,0 2,-0.8954305 2,-2 v -4 h 4 v 2.27148 c -0.3037,-0.176771 -0.6486,-0.2704071 -1,-0.27148 -1.1046,0 -2,0.8954305 -2,2 0,1.1045695 0.8954,2 2,2 1.1046,0 2,-0.8954305 2,-2 v -4 -0.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z m -1.5,4 c 0.5523,0 1,0.4477153 1,1 0,0.55228475 -0.4477,1 -1,1 -0.5523,0 -1,-0.44771525 -1,-1 0,-0.5522847 0.4477,-1 1,-1 z m 5,0 c 0.5523,0 1,0.4477153 1,1 0,0.55228475 -0.4477,1 -1,1 -0.5523,0 -1,-0.44771525 -1,-1 0,-0.5522847 0.4477,-1 1,-1 z"
+         style="opacity:1;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;font-variant-east_asian:normal;vector-effect:none;paint-order:normal"
+         sodipodi:nodetypes="sscccsssccccssscsssssssssssss" />
+      <path
+         style="display:inline;opacity:1;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;paint-order:normal"
+         d="m 2495,-103 c -0.554,0 -1,0.446 -1,1 v 1 4.341797 c -0.4685,-0.22377 -0.9808,-0.34053 -1.5,-0.3418 -1.933,0 -3.5,1.567 -3.5,3.5 0,1.933 1.567,3.5 3.5,3.5 1.933,0 3.5,-1.567 3.5,-3.5 V -101 h 6 v 4.341797 c -0.4685,-0.22377 -0.9808,-0.34053 -1.5,-0.3418 -1.933,0 -3.5,1.567 -3.5,3.5 0,1.933 1.567,3.5 3.5,3.5 1.933,0 3.5,-1.567 3.5,-3.5 V -101 v -1 c 0,-0.554 -0.446,-1 -1,-1 z m -2.5,7.999997 c 0.8284,0 1.5,0.67157 1.5,1.5 0,0.82843 -0.6716,1.5 -1.5,1.5 -0.8284,0 -1.5,-0.67157 -1.5,-1.5 0,-0.82843 0.6716,-1.5 1.5,-1.5 z m 8,0 c 0.8284,0 1.5,0.67157 1.5,1.5 0,0.82843 -0.6716,1.5 -1.5,1.5 -0.8284,0 -1.5,-0.67157 -1.5,-1.5 0,-0.82843 0.6716,-1.5 1.5,-1.5 z"
+         id="path11327"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscccsssccccssscsssssssssssss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;marker:none;paint-order:normal"
+         d="m 2501,-175 a 1.0001,1.0001 0 0 0 -1,1 v 8.76562 c -0.7164,-0.48221 -1.5771,-0.76562 -2.5,-0.76562 -2.4734,0 -4.5,2.02656 -4.5,4.5 0,2.47344 2.0266,4.5 4.5,4.5 2.4734,0 4.5,-2.02656 4.5,-4.5 0,-0.17095 -0.032,-0.33384 -0.051,-0.5 H 2502 v -11 h 9 v 7.76562 c -0.7164,-0.48221 -1.5771,-0.76562 -2.5,-0.76562 -2.4734,0 -4.5,2.02656 -4.5,4.5 0,2.47344 2.0266,4.5 4.5,4.5 2.4734,0 4.5,-2.02656 4.5,-4.5 0,-0.17095 -0.032,-0.33384 -0.051,-0.5 H 2513 v -12 a 1.0001,1.0001 0 0 0 -1,-1 z m -3.5,11 c 1.3926,0 2.5,1.10744 2.5,2.5 0,1.39256 -1.1074,2.5 -2.5,2.5 -1.3926,0 -2.5,-1.10744 -2.5,-2.5 0,-1.39256 1.1074,-2.5 2.5,-2.5 z m 11,0 c 1.3926,0 2.5,1.10744 2.5,2.5 0,1.39256 -1.1074,2.5 -2.5,2.5 -1.3926,0 -2.5,-1.10744 -2.5,-2.5 0,-1.39256 1.1074,-2.5 2.5,-2.5 z"
+         id="path2956"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;enable-background:new;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;font-variant-east_asian:normal"
+         d="M 2160 848 L 2160 934.50781 C 2159.8653 935.23822 2159.2812 935.45938 2158.7188 935.09375 L 2158.7266 935.14453 C 2152.26 930.64869 2144.4259 928 2136 928 C 2114.0034 928 2096 946.00337 2096 968 C 2096 989.99663 2114.0034 1008 2136 1008 C 2157.9966 1008 2176 989.99663 2176 968 L 2176 864 L 2256 864 L 2256 934.41797 C 2255.8972 935.21787 2255.2933 935.47353 2254.709 935.09375 L 2254.7168 935.13672 C 2248.2522 930.64521 2240.4214 928 2232 928 C 2210.0034 928 2192 946.00337 2192 968 C 2192 989.99663 2210.0034 1008 2232 1008 C 2253.9966 1008 2272 989.99663 2272 968 L 2272 848 L 2160 848 z M 2136 944 C 2149.3496 944 2160 954.65041 2160 968 C 2160 981.34959 2149.3496 992 2136 992 C 2122.6504 992 2112 981.34959 2112 968 C 2112 954.65041 2122.6504 944 2136 944 z M 2232 944 C 2245.3496 944 2256 954.65041 2256 968 C 2256 981.34959 2245.3496 992 2232 992 C 2218.6504 992 2208 981.34959 2208 968 C 2208 954.65041 2218.6504 944 2232 944 z "
+         id="path5670-3"
+         transform="translate(0,-852)" />
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:folder-pictures"
+     id="g11477">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g11449"
+       inkscape:groupmode="layer">
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11425"
+         width="48"
+         height="48"
+         x="3120"
+         y="-195.99998"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-116"
+         x="3120"
+         height="32"
+         width="32"
+         id="rect11427"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect11429"
+         width="22"
+         height="22"
+         x="3121"
+         y="-58.941162"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-12"
+         x="3120"
+         height="16"
+         width="16"
+         id="rect11431"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-60"
+         x="3120"
+         height="24"
+         width="24"
+         id="rect11433"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text11437"
+         y="-279.63733"
+         x="3246.9438"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.63733"
+           x="3246.9438"
+           id="tspan11435"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="2686.3528"
+         y="-279.83838"
+         id="text11441"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           x="2686.3528"
+           y="-279.83838"
+           id="tspan11439"
+           style="font-size:14.66666698px;line-height:18.33333397">folder-pictures</tspan></text>
+      <g
+         transform="translate(2560,0)"
+         style="display:inline;enable-background:new"
+         id="g11447">
+        <rect
+           inkscape:label="512x512"
+           y="-228"
+           x="16"
+           height="512"
+           width="512"
+           id="rect11443"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           id="path11445"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g11453"
+       inkscape:groupmode="layer">
+      <use
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1"
+         x="0"
+         y="0"
+         xlink:href="#g11603"
+         id="use5395"
+         transform="translate(2560)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g11475"
+       inkscape:label="symbols"
+       style="display:inline">
+      <path
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 3134,-102 c -0.55,0 -1,0.45004 -1,1 v 1 h -3 c -0.552,0 -1,0.45004 -1,1 v 8 c 0,0.54996 0.448,1 1,1 h 12 c 0.552,0 1,-0.45004 1,-1 v -8 c 0,-0.54996 -0.448,-1 -1,-1 h -3 v -1 c 0,-0.54996 -0.45,-1 -1,-1 z m 2,3 c 2.2091,0 4,1.79086 4,4 0,2.20914 -1.7909,4 -4,4 -2.2091,0 -4,-1.79086 -4,-4 0,-2.20914 1.7909,-4 4,-4 z m 0,2 c -1.1046,0 -2,0.89543 -2,2 0,1.10457 0.8954,2 2,2 1.1046,0 2,-0.89543 2,-2 0,-1.10457 -0.8954,-2 -2,-2 z"
+         id="path1503"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path1514"
+         d="m 3130.375,-49.5 c -0.4812,0 -0.875,0.39378 -0.875,0.875 v 1.125 h -2.625 c -0.483,0 -0.875,0.39378 -0.875,0.875 v 5.75 c 0,0.48122 0.392,0.875 0.875,0.875 h 10.25 c 0.483,0 0.875,-0.39378 0.875,-0.875 v -5.75 c 0,-0.48122 -0.392,-0.875 -0.875,-0.875 h -2.625 v -1.125 c 0,-0.48122 -0.3938,-0.875 -0.875,-0.875 z M 3132,-47 c 1.648,0 3,1.35203 3,3 0,1.64797 -1.352,3 -3,3 -1.6479,0 -3,-1.35203 -3,-3 0,-1.64797 1.3521,-3 3,-3 z m 0,1.5 c -0.8373,0 -1.5,0.66269 -1.5,1.5 0,0.83731 0.6627,1.5 1.5,1.5 0.8373,0 1.5,-0.66269 1.5,-1.5 0,-0.83731 -0.6627,-1.5 -1.5,-1.5 z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1516"
+         d="m 3127.5,-5 c -0.275,0 -0.5,0.22502 -0.5,0.5 V -4 h -1.5 c -0.276,0 -0.5,0.22502 -0.5,0.5 v 4 c 0,0.27498 0.224,0.5 0.5,0.5 h 6 c 0.276,0 0.5,-0.22502 0.5,-0.5 v -4 c 0,-0.27498 -0.224,-0.5 -0.5,-0.5 h -1.5 v -0.5 c 0,-0.27498 -0.225,-0.5 -0.5,-0.5 z m 1,1.5 c 1.1046,0 2,0.89543 2,2 0,1.10457 -0.8954,2 -2,2 -1.1045,0 -2,-0.89543 -2,-2 0,-1.10457 0.8955,-2 2,-2 z m 0,1 c -0.5523,0 -1,0.447715 -1,1 0,0.552285 0.4477,1 1,1 0.5523,0 1,-0.447715 1,-1 0,-0.552285 -0.4477,-1 -1,-1 z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="M 2799.8125 832 C 2795.0802 832 2791.6683 834.10443 2788.9531 836.79102 C 2786.6304 839.0892 2784.7487 842.19484 2784.2266 846.05469 L 2778.2344 864.06055 L 2748.0156 864 A 8.0008 8.0008 0 0 0 2748 864 C 2739.3333 864 2732.7978 869.51376 2730.3438 874.42188 C 2727.8897 879.32999 2728 884 2728 884 A 8.0008 8.0008 0 0 0 2728 884.00977 L 2728.1504 1000.0098 A 8.0008 8.0008 0 0 0 2736.1504 1008 L 2928.1289 1008 A 8.0008 8.0008 0 0 0 2936.1289 999.99023 L 2936 884 C 2936 875.33333 2930.4862 868.79781 2925.5781 866.34375 C 2920.67 863.88969 2916 864 2916 864 A 8.0008 8.0008 0 0 0 2915.9453 864 L 2885.75 864.20898 L 2879.7715 846.10938 C 2879.2912 842.39902 2877.5598 839.33448 2875.2344 836.95703 C 2872.5115 834.1729 2868.7382 832 2864 832 L 2799.8125 832 z M 2800.5156 848 L 2863.5879 848 C 2863.6149 848.0123 2863.6894 848.03463 2863.7969 848.14453 C 2864.0463 848.3995 2863.9805 848.74889 2863.9805 848.03125 A 8.0008 8.0008 0 0 0 2864.3828 850.53906 L 2872.3828 874.75781 A 8.0008 8.0008 0 0 0 2880.0352 880.24805 L 2916 880 C 2916 880.00017 2917.3288 880.11072 2918.4199 880.65625 C 2919.5138 881.20219 2920 880.66667 2920 884 A 8.0008 8.0008 0 0 0 2920 884.00977 L 2920.1191 992 L 2744.1387 992 L 2744 884 C 2744 884 2744.1103 882.67001 2744.6562 881.57812 C 2745.2023 880.48624 2744.6667 880 2748 880 L 2783.9844 880.07227 A 8.0008 8.0008 0 0 0 2791.5898 874.59766 L 2799.5898 850.55664 A 8.0008 8.0008 0 0 0 2799.9941 848.25391 C 2799.9801 848.47332 2799.9751 848.39348 2800.207 848.16406 C 2800.336 848.03645 2800.4597 848.01441 2800.5156 848 z M 2832 880 C 2805.5851 880 2784 901.58509 2784 928 C 2784 954.41491 2805.5851 976 2832 976 C 2858.4149 976 2880 954.41491 2880 928 C 2880 901.58509 2858.4149 880 2832 880 z M 2832 896 C 2849.7679 896 2864 910.23213 2864 928 C 2864 945.76787 2849.7679 960 2832 960 C 2814.2321 960 2800 945.76787 2800 928 C 2800 910.23213 2814.2321 896 2832 896 z "
+         transform="translate(0,-852)"
+         id="path5668" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3139.8145,-174.93945 c -0.5547,0 -0.9401,0.24217 -1.2481,0.54687 -0.3079,0.3047 -0.5664,0.72784 -0.5664,1.28906 v 2.12305 h -3.1387 c -1.0164,0 -1.7734,0.80641 -1.7734,1.82617 V -157 a 1.0001,1.0001 0 0 0 1,1 h 20 a 1.0001,1.0001 0 0 0 1,-1 v -12.13281 c 0,-0.54288 -0.2248,-0.91841 -0.5313,-1.23828 -0.3064,-0.31988 -0.7616,-0.58985 -1.3339,-0.58985 H 3150 v -2.14258 c 0,-0.53713 -0.2316,-0.95314 -0.541,-1.26953 -0.3094,-0.31638 -0.7411,-0.5664 -1.291,-0.5664 z m 0.1855,2 h 8 v 2.97851 a 1.0001,1.0001 0 0 0 1,1 h 4.0879 V -158 h -18 v -10.98047 H 3139 a 1.0001,1.0001 0 0 0 1,-1 z"
+         id="path5668-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3143.9961,-169 c -2.7069,0 -4.9219,2.21501 -4.9219,4.92188 0,2.70686 2.215,4.92382 4.9219,4.92382 2.7069,0 4.9238,-2.21696 4.9238,-4.92382 0,-2.70687 -2.2169,-4.92188 -4.9238,-4.92188 z m 0,2 c 1.626,0 2.9238,1.29589 2.9238,2.92188 0,1.62598 -1.2978,2.92382 -2.9238,2.92382 -1.626,0 -2.9219,-1.29784 -2.9219,-2.92382 0,-1.62599 1.2959,-2.92188 2.9219,-2.92188 z"
+         id="path5670-6"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     id="g13700"
+     inkscape:label="artwork:folder-publicshare"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g13594"
+       inkscape:label="baseplate"
+       style="display:none">
+      <rect
+         inkscape:label="48x48"
+         y="-195.99998"
+         x="3760"
+         height="48"
+         width="48"
+         id="rect13570"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect13572"
+         width="32"
+         height="32"
+         x="3760"
+         y="-116"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-58.941162"
+         x="3761"
+         height="22"
+         width="22"
+         id="rect13574"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect13576"
+         width="16"
+         height="16"
+         x="3760"
+         y="-12"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect13578"
+         width="24"
+         height="24"
+         x="3760"
+         y="-60"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="3246.9438"
+         y="-279.63733"
+         id="text13582"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan13580"
+           x="3246.9438"
+           y="-279.63733"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text13586"
+         y="-279.83838"
+         x="3326.3528"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           id="tspan13584"
+           y="-279.83838"
+           x="3326.3528"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">folder-publicshare</tspan></text>
+      <g
+         id="g13592"
+         style="display:inline;enable-background:new"
+         transform="translate(3200,0)">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect13588"
+           width="512"
+           height="512"
+           x="16"
+           y="-228"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path13590"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g13676"
+       inkscape:label="icons"
+       style="display:inline">
+      <use
+         height="100%"
+         width="100%"
+         transform="translate(3199.9999)"
+         id="use5683"
+         xlink:href="#g11603"
+         y="0"
+         x="0"
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1" />
+    </g>
+    <g
+       inkscape:label="symbols"
+       id="g13698"
+       inkscape:groupmode="layer"
+       style="display:inline">
+      <g
+         id="g1424"
+         transform="translate(3423.8093,-1066.1781)"
+         inkscape:label="emblem-shared"
+         style="display:inline;enable-background:new;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill:#b5835a;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+        <path
+           inkscape:connector-curvature="0"
+           id="path1416"
+           d="m 350.1907,970.1781 a 2.5,2.5 0 0 1 -2.5,2.5 2.5,2.5 0 0 1 -2.5,-2.5 2.5,2.5 0 0 1 2.5,-2.5 2.5,2.5 0 0 1 2.5,2.5 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1418"
+           d="m 358.1907,974.6781 a 2.5,2.5 0 0 1 -2.5,2.5 2.5,2.5 0 0 1 -2.5,-2.5 2.5,2.5 0 0 1 2.5,-2.5 2.5,2.5 0 0 1 2.5,2.5 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1420"
+           d="m 358.1907,965.6781 a 2.5,2.5 0 0 1 -2.5,2.5 2.5,2.5 0 0 1 -2.5,-2.5 2.5,2.5 0 0 1 2.5,-2.5 2.5,2.5 0 0 1 2.5,2.5 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 356.07227,964.31641 -0.8711,0.49023 -8,4.5 a 1.0001,1.0001 0 0 0 0,1.74219 l 8,4.5 0.8711,0.49023 0.98046,-1.74218 -0.87109,-0.49024 -6.45117,-3.62891 6.45117,-3.6289 0.87109,-0.49024 z"
+           id="path1422"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="display:inline;enable-background:new;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill:#b5835a;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:label="emblem-shared"
+         transform="matrix(0.5,0,0,0.5,3592.4047,-487.08905)"
+         id="g1459">
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1"
+           d="m 349.6906,970.1781 a 2.5,2.5 0 0 1 -2.5,2.5 2.5,2.5 0 0 1 -2.5,-2.5 2.5,2.5 0 0 1 2.5,-2.5 2.5,2.5 0 0 1 2.5,2.5 z"
+           id="path1451"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1"
+           d="m 357.6906,974.1781 a 2.5,2.5 0 0 1 -2.5,2.5 2.5,2.5 0 0 1 -2.5,-2.5 2.5,2.5 0 0 1 2.5,-2.5 2.5,2.5 0 0 1 2.5,2.5 z"
+           id="path1453"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1"
+           d="m 357.6906,966.1781 a 2.5,2.5 0 0 1 -2.5,2.5 2.5,2.5 0 0 1 -2.5,-2.5 2.5,2.5 0 0 1 2.5,-2.5 2.5,2.5 0 0 1 2.5,2.5 z"
+           id="path1455"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 355.63867,964.83594 -0.89453,0.44726 -8,4 a 1.0001,1.0001 0 0 0 0,1.78907 l 8,4 0.89453,0.44726 0.89453,-1.78906 -0.89453,-0.44727 -6.21094,-3.10547 6.21094,-3.10546 0.89453,-0.44727 z"
+           id="path1457"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1471"
+         transform="matrix(0.49999998,0,0,0.49999998,3594.4047,-530.58903)"
+         inkscape:label="emblem-shared"
+         style="display:inline;enable-background:new;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill:#b5835a;fill-opacity:1;stroke:none;stroke-width:32.00000128;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+        <path
+           inkscape:connector-curvature="0"
+           id="path1463"
+           d="m 351.1282,970.14685 a 2.96875,2.96875 0 0 1 -2.96875,2.96875 2.96875,2.96875 0 0 1 -2.96875,-2.96875 2.96875,2.96875 0 0 1 2.96875,-2.96875 2.96875,2.96875 0 0 1 2.96875,2.96875 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32.00000128;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1465"
+           d="m 363.15936,976.14685 a 2.96875,2.96875 0 0 1 -2.96875,2.96875 2.96875,2.96875 0 0 1 -2.96875,-2.96875 2.96875,2.96875 0 0 1 2.96875,-2.96875 2.96875,2.96875 0 0 1 2.96875,2.96875 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32.00000128;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1467"
+           d="m 363.15936,964.14685 a 2.96875,2.96875 0 0 1 -2.96875,2.96875 2.96875,2.96875 0 0 1 -2.96875,-2.96875 2.96875,2.96875 0 0 1 2.96875,-2.96875 2.96875,2.96875 0 0 1 2.96875,2.96875 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32.00000128;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:1" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 360.63867,962.83594 -0.89453,0.44726 -12,6 a 1.0001,1.0001 0 0 0 0,1.78907 l 12,6 0.89453,0.44726 0.89453,-1.78906 -0.89453,-0.44727 -10.21094,-5.10547 10.21094,-5.10546 0.89453,-0.44727 z"
+           id="path1469"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3789,-177 c -2.1973,0 -4,1.80271 -4,4 0,2.19729 1.8027,4 4,4 2.1973,0 4,-1.80271 4,-4 0,-2.19729 -1.8027,-4 -4,-4 z m 0,2 c 1.1164,0 2,0.88359 2,2 0,1.11641 -0.8836,2 -2,2 -1.1164,0 -2,-0.88359 -2,-2 0,-1.11641 0.8836,-2 2,-2 z"
+         id="path6019-5"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3777,-171 c -2.1973,0 -4,1.80271 -4,4 0,2.19729 1.8027,4 4,4 2.1973,0 4,-1.80271 4,-4 0,-2.19729 -1.8027,-4 -4,-4 z m 0,2 c 1.1164,0 2,0.88359 2,2 0,1.11641 -0.8836,2 -2,2 -1.1164,0 -2,-0.88359 -2,-2 0,-1.11641 0.8836,-2 2,-2 z"
+         id="circle6040-4"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3789,-165 c -2.1973,0 -4,1.80271 -4,4 0,2.19729 1.8027,4 4,4 2.1973,0 4,-1.80271 4,-4 0,-2.19729 -1.8027,-4 -4,-4 z m 0,2 c 1.1164,0 2,0.88359 2,2 0,1.11641 -0.8836,2 -2,2 -1.1164,0 -2,-0.88359 -2,-2 0,-1.11641 0.8836,-2 2,-2 z"
+         id="circle6042-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3780.2559,-166.43555 a 1.0001,1.0001 0 0 0 -0.4121,1.90039 l 5.7187,2.85938 a 1.0001,1.0001 0 1 0 0.8945,-1.78711 l -5.7187,-2.86133 a 1.0001,1.0001 0 0 0 -0.4824,-0.11133 z"
+         id="path6044-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 3786.0137,-172.1543 a 1.0001,1.0001 0 0 0 -0.4512,0.11133 l -5.7187,2.85938 a 1.0001082,1.0001082 0 1 0 0.8945,1.78906 l 5.7187,-2.85938 a 1.0001,1.0001 0 0 0 -0.4433,-1.90039 z"
+         id="path6046-5"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 3520,-20 c -21.9966,0 -40,18.00337 -40,40 0,3.07931 0.3641,6.07658 1.0312,8.96094 l -0.037,-0.03711 c 0.1697,0.8212 -0.5051,1.83189 -1.1035,2.18359 l 0.6192,0.0078 -39.7071,19.68946 c -0.7463,0.26797 -1.7855,-0.0975 -2.25,-0.55469 l 0.01,0.02734 C 3431.2074,41.56361 3420.2226,36 3408,36 c -21.9966,0 -40,18.00337 -40,40 0,21.99663 18.0034,40 40,40 12.2261,0 23.2133,-5.56714 30.5664,-14.28516 l -0.031,0.22852 c 0.5564,-0.62741 1.7703,-0.69074 2.4101,-0.42188 l -0.01,-0.008 39.2265,20.45899 -0.5058,0.0644 c 0.75,0.375 1.1252,1.53125 1.0312,2.21875 l 0.094,-0.11524 C 3480.273,126.68389 3480,129.31189 3480,132 c 0,21.9966 18.0034,40 40,40 21.9966,0 40,-18.0034 40,-40 0,-21.99663 -18.0034,-40 -40,-40 -12.6772,0 -24.0207,5.9859 -31.3633,15.26367 l 0.019,-0.13867 c -0.305,0.34397 -0.8053,0.50572 -1.3027,0.54883 l -39.3262,-20.50977 0.066,-0.0078 c -0.75,-0.375 -1.1253,-1.53125 -1.0313,-2.21875 l -0.125,0.1543 C 3447.6245,82.16732 3448,79.12599 3448,76 c 0,-3.05925 -0.3608,-6.03722 -1.0195,-8.9043 l 0.064,0.0625 c -0.1566,-0.75797 0.4068,-1.65473 0.9649,-2.06836 l 40.1504,-19.91015 c 0.3616,0.01325 0.7281,0.11984 1.0449,0.27148 C 3496.558,54.32291 3507.6492,60 3520,60 c 21.9966,0 40,-18.00337 40,-40 0,-21.99663 -18.0034,-40 -40,-40 z m 0,16 c 13.3496,0 24,10.65041 24,24 0,13.34959 -10.6504,24 -24,24 -13.3496,0 -24,-10.65041 -24,-24 0,-13.34959 10.6504,-24 24,-24 z m -112,56 c 13.3496,0 24,10.65041 24,24 0,13.34959 -10.6504,24 -24,24 -13.3496,0 -24,-10.65041 -24,-24 0,-13.34959 10.6504,-24 24,-24 z m 112,56 c 13.3496,0 24,10.65041 24,24 0,13.34959 -10.6504,24 -24,24 -13.3496,0 -24,-10.65041 -24,-24 0,-13.34959 10.6504,-24 24,-24 z"
+         id="path6019"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:folder-templates"
+     id="g14008">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g13902"
+       inkscape:groupmode="layer">
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect13878"
+         width="48"
+         height="48"
+         x="4400"
+         y="-195.99998"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-116"
+         x="4400"
+         height="32"
+         width="32"
+         id="rect13880"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect13882"
+         width="22"
+         height="22"
+         x="4401"
+         y="-58.941162"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-12"
+         x="4400"
+         height="16"
+         width="16"
+         id="rect13884"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-60"
+         x="4400"
+         height="24"
+         width="24"
+         id="rect13886"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text13890"
+         y="-279.63733"
+         x="3886.9438"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.63733"
+           x="3886.9438"
+           id="tspan13888"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="3966.353"
+         y="-279.83838"
+         id="text13894"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           x="3966.353"
+           y="-279.83838"
+           id="tspan13892"
+           style="font-size:14.66666698px;line-height:18.33333397">folder-templates</tspan></text>
+      <g
+         style="display:inline;enable-background:new"
+         id="g13900"
+         transform="translate(3840,0)">
+        <rect
+           inkscape:label="512x512"
+           y="-228"
+           x="16"
+           height="512"
+           width="512"
+           id="rect13896"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           id="path13898"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g13984"
+       inkscape:groupmode="layer">
+      <use
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1"
+         x="0"
+         y="0"
+         xlink:href="#g11603"
+         id="use5689"
+         transform="translate(3839.9999)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g14006"
+       inkscape:label="symbols"
+       style="display:inline">
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path14170"
+         d="m 4418,-175 c -0.5523,5e-5 -0.9999,0.44773 -1,1 v 5 h 2 v -4 h 6 v 4 h 4 v 10 2 h 1 c 0.5523,-6e-5 0.9999,-0.44774 1,-1 v -11.5 c -1e-4,-0.2652 -0.1054,-0.51952 -0.293,-0.70703 l -4.5,-4.5 c -0.1875,-0.18754 -0.4418,-0.29292 -0.707,-0.29297 z m -1,8 v 2 h 2 v -2 z m 0,4 v 2 h 2 v -2 z m 0,4 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none"
+         d="m 4409.5,-49 c -0.2762,3e-5 -0.4999,0.22387 -0.5,0.5 v 1.5 h 1 v -1 h 3 v 2 h 2 v 4 1 h 0.5 c 0.2761,-3e-5 0.4999,-0.22387 0.5,-0.5 v -4.75 c -1e-4,-0.1326 -0.053,-0.25976 -0.1465,-0.35352 l -2.25,-2.25 c -0.094,-0.0938 -0.2209,-0.14645 -0.3535,-0.14648 z m -0.5,3 v 1 h 1 v -1 z m 0,2 v 1 h 1 v -1 z m 0,2 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z"
+         id="path14198"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none"
+         d="m 4412,-103 c -0.5523,5e-5 -0.9999,0.44773 -1,1 v 3 h 2 v -2 h 4 v 3 h 3 v 6 2 h 2 v -8.5 c -1e-4,-0.2652 -0.1054,-0.51952 -0.293,-0.70703 l -3.5,-3.5 c -0.1875,-0.18754 -0.4418,-0.29292 -0.707,-0.29297 z m -1,5 v 2 h 2 v -2 z m 0,3 v 2 h 2 v -2 z m 0,3 v 2 h 2 v -2 z m 3,0 v 2 h 2 v -2 z m 3,0 v 2 h 2 v -2 z"
+         id="path14250"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccc" />
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path14269"
+         d="m 4405.5,-6 c -0.2762,3e-5 -0.4999,0.22387 -0.5,0.5 V -4 h 1 v -1 h 3 v 2 h 2 v 4 1 h 0.5 c 0.2761,-3e-5 0.4999,-0.22387 0.5,-0.5 v -4.75 c -1e-4,-0.1326 -0.053,-0.25976 -0.1465,-0.35352 l -2.25,-2.25 c -0.094,-0.0938 -0.2209,-0.14645 -0.3535,-0.14648 z m -0.5,3 v 1 h 1 v -1 z m 0,2 v 1 h 1 v -1 z m 0,2 v 1 h 1 V 1 Z m 2,0 v 1 h 1 V 1 Z m 2,0 v 1 h 1 V 1 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none"
+         d="m 4056,-4 c -4.418,4.4e-4 -7.9996,3.5819 -8,8 v 56 h 16 V 12 h 64 v 32 h 32 v 96 h -16 v 16 h 24 c 4.4182,-4.4e-4 7.9996,-3.5819 8,-8 V 40 c -4e-4,-2.12158 -0.8433,-4.15617 -2.3438,-5.65625 l -36,-36 C 4136.1562,-3.15655 4134.1216,-3.99958 4132,-4 Z m -8,80 v 16 h 16 V 76 Z m 0,32 v 16 h 16 v -16 z m 0,32 v 16 h 16 v -16 z m 32,0 v 16 h 16 v -16 z m 32,0 v 16 h 16 v -16 z"
+         id="path8659-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccc" />
+    </g>
+  </g>
+  <g
+     id="g14432"
+     inkscape:label="artwork:folder-videos"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g14325"
+       inkscape:label="baseplate"
+       style="display:none">
+      <rect
+         inkscape:label="48x48"
+         y="-195.99998"
+         x="5040"
+         height="48"
+         width="48"
+         id="rect14301"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect14303"
+         width="32"
+         height="32"
+         x="5040"
+         y="-116"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-58.941162"
+         x="5041"
+         height="22"
+         width="22"
+         id="rect14305"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect14307"
+         width="16"
+         height="16"
+         x="5040"
+         y="-12"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect14309"
+         width="24"
+         height="24"
+         x="5040"
+         y="-60"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="4526.9438"
+         y="-279.63733"
+         id="text14313"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan14311"
+           x="4526.9438"
+           y="-279.63733"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text14317"
+         y="-279.83838"
+         x="4606.353"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           id="tspan14315"
+           y="-279.83838"
+           x="4606.353"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">folder-videos</tspan></text>
+      <g
+         id="g14323"
+         style="display:inline;enable-background:new"
+         transform="translate(4480,0)">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect14319"
+           width="512"
+           height="512"
+           x="16"
+           y="-228"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path14321"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g14408"
+       inkscape:label="icons"
+       style="display:inline">
+      <use
+         height="100%"
+         width="100%"
+         transform="translate(4479.9999)"
+         id="use5771"
+         xlink:href="#g11603"
+         y="0"
+         x="0"
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1" />
+    </g>
+    <g
+       inkscape:label="symbols"
+       id="g14430"
+       inkscape:groupmode="layer"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6846"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+         d="M 5053.0002,-95.5307 5049.5309,-99 H 5049 v 7 h 0.5 z M 5061.9691,-100 H 5054 c -0.5539,0 -0.9998,0.446 -0.9998,1 v 7 c 0,0.554 0.4459,1 0.9998,1 h 7.9691 c 0.5539,0 0.9999,-0.446 0.9999,-1 v -7 c 0,-0.554 -0.446,-1 -0.9999,-1 z" />
+      <path
+         sodipodi:nodetypes="ccccccsssssssss"
+         inkscape:connector-curvature="0"
+         id="path6846-4"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+         d="M 5050.0031,-45.085816 5047.9164,-47 H 5047 v 4 h 0.8963 z M 5055.351,-48 h -4.696 c -0.3612,0 -0.6519,0.290808 -0.6519,0.652038 v 4.695915 c 0,0.361239 0.2907,0.652047 0.6519,0.652047 h 4.696 c 0.3612,0 0.652,-0.290808 0.652,-0.652047 v -4.695915 c 0,-0.36123 -0.2908,-0.652038 -0.652,-0.652038 z" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+         d="m 5047.75,848 c -0.4155,0 -0.75,0.3345 -0.75,0.75 v 2.25 1.25 c 0,0.4155 0.3345,0.75 0.75,0.75 h 3.5 c 0.4155,0 0.75,-0.3345 0.75,-0.75 v -3.5 c 0,-0.4155 -0.3345,-0.75 -0.75,-0.75 z m -0.75,3 v -1 l -2,-1 h -1 v 3 h 1 z"
+         id="path20928"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscsssssssccccccc"
+         transform="translate(0,-852)" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 5054.0332,-172 a 1.0000999,1.0000999 0 0 0 -1.0332,1 v 9 a 1.0000999,1.0000999 0 0 0 1.6699,0.74414 l 5,-4.5 a 1.0000999,1.0000999 0 0 0 0,-1.48828 l -5,-4.5 A 1.0000999,1.0000999 0 0 0 5054.0332,-172 Z m 0.9668,3.24609 2.5039,2.25391 -2.5039,2.25391 z"
+         id="path5690-5"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal"
+         d="m 5061.5,-173 c -1.3677,0 -2.5,1.1323 -2.5,2.5 v 8 c 0,1.3677 1.1323,2.5 2.5,2.5 h 11 c 1.3677,0 2.5,-1.1323 2.5,-2.5 v -8 c 0,-1.3677 -1.1323,-2.5 -2.5,-2.5 z m 0,2 h 11 c 0.2943,0 0.5,0.2057 0.5,0.5 v 8 c 0,0.2943 -0.2057,0.5 -0.5,0.5 h -11 c -0.2943,0 -0.5,-0.2057 -0.5,-0.5 v -8 c 0,-0.2943 0.2057,-0.5 0.5,-0.5 z"
+         id="rect5692-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;font-variant-east_asian:normal"
+         d="M 4713.9902 864.07031 C 4699.7246 864.07031 4687.9902 875.80469 4687.9902 890.07031 L 4687.9902 918.60547 L 4653.8086 882.5 A 8.000799 8.000799 0 0 0 4648.1016 880.00195 A 8.000799 8.000799 0 0 0 4648 880.00586 L 4648 880 L 4640 880 L 4640 888 L 4640 892 L 4640 964 L 4640 968 L 4640 976 L 4648 976 L 4648 975.99219 A 8.000799 8.000799 0 0 0 4653.6348 973.67969 L 4687.9902 939.59375 L 4687.9902 966 C 4687.9902 980.26562 4699.7246 992 4713.9902 992 L 4822 992 C 4836.2656 992 4848 980.26562 4848 966 L 4848 890.07031 C 4848 875.80469 4836.2656 864.07031 4822 864.07031 L 4713.9902 864.07031 z M 4713.9902 880.07031 L 4822 880.07031 C 4827.6784 880.07031 4832 884.39194 4832 890.07031 L 4832 966 C 4832 971.67838 4827.6784 976 4822 976 L 4713.9902 976 C 4708.3119 976 4703.9902 971.67838 4703.9902 966 L 4703.9902 890.07031 C 4703.9902 884.39194 4708.3119 880.07031 4713.9902 880.07031 z M 4656 908.08789 L 4675.8711 929.07812 L 4656 948.79297 L 4656 908.08789 z "
+         id="path5690"
+         transform="translate(0,-852)" />
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:user-bookmarks"
+     id="g14805">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g14699"
+       inkscape:groupmode="layer">
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect14675"
+         width="48"
+         height="48"
+         x="5680"
+         y="-195.99998"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-116"
+         x="5680"
+         height="32"
+         width="32"
+         id="rect14677"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect14679"
+         width="22"
+         height="22"
+         x="5681"
+         y="-58.941162"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-12"
+         x="5680"
+         height="16"
+         width="16"
+         id="rect14681"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-60"
+         x="5680"
+         height="24"
+         width="24"
+         id="rect14683"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text14687"
+         y="-279.63733"
+         x="5166.9438"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.63733"
+           x="5166.9438"
+           id="tspan14685"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="5246.353"
+         y="-279.83838"
+         id="text14691"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           x="5246.353"
+           y="-279.83838"
+           id="tspan14689"
+           style="font-size:14.66666698px;line-height:18.33333397">user-bookmarks</tspan></text>
+      <g
+         transform="translate(5120,0)"
+         style="display:inline;enable-background:new"
+         id="g14697">
+        <rect
+           inkscape:label="512x512"
+           y="-228"
+           x="16"
+           height="512"
+           width="512"
+           id="rect14693"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           id="path14695"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g14781"
+       inkscape:groupmode="layer">
+      <use
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1"
+         x="0"
+         y="0"
+         xlink:href="#g11603"
+         id="use5796"
+         transform="translate(5119.9999)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g14803"
+       inkscape:label="symbols"
+       style="display:inline">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+         d="m 5374.1557,0.3504434 0.168,-0.57032 -14.6758,44.2070366 h -45.7422 c -5.427,0 -10.0102,2.57618 -13.1562,6.42188 -6.972,8.03086 -5.465,19.93074 3.3358,25.92968 l -0.2382,-0.168 36.918,27.1836 -14.207,44.48438 c -0.026,0.0816 -0.05,0.1636 -0.074,0.2461 -2.138,7.51304 1.7382,14.40214 6.7538,18.17968 5.0156,3.77754 12.736,5.59454 19.3476,1.41406 0.16,-0.1 0.3164,-0.20544 0.4688,-0.3164 l 37.5548,-27.65234 37.5547,27.65234 c 0.116,0.0838 0.2322,0.1646 0.3516,0.24218 6.7456,4.43144 15.2444,3.74634 21.2148,-1.60936 0.032,-0.0296 0.066,-0.0596 0.098,-0.0898 4.9768,-4.61408 6.8492,-11.41032 4.875,-17.9414 -0.02,-0.0392 -0.024,-0.0782 -0.036,-0.1172 l -14.2108,-44.48438 36.9102,-27.18752 -0.2462,0.1758 c 8.8208,-5.99282 10.3016,-17.90228 3.3476,-25.92578 -3.2182,-3.9493 -7.8148,-6.26114 -12.8944,-6.42578 -0.088,-0.002 -0.174,-0.004 -0.2618,-0.004 h -46.5586 l -13.8242,-44.0820366 0.102,0.35156 c -5.0332,-16.7333714 -28.6379,-15.8618514 -32.8753,0.086 z m 16.4334,3.0665002 c 0.182,0.0742 0.369,0.0828 0.4766,0.1874 0.04,0.0382 0.078,0.0758 0.118,0.1132 0.154,0.1432 0.3366,0.45796 0.3828,0.6328 0.032,0.1166 0.066,0.23256 0.102,0.34766 l 15.0197,47.9023364 c 1.9043,3.97581 6.6547,7.39454 11.1562,7.39454 h 49.2226 c 1.9114,-0.0977 2.3485,2.1516 0.8164,3.29688 l -39.75,29.27736 c -4.0481,2.98156 -5.2311,8.41198 -3.3358,14.34376 l 14.5976,45.6875 c 0.4658,1.4579 -1.4098,2.11918 -2.0704,1.6328 l -39.4258,-29.02734 c -3.6651,-3.61942 -9.8073,-3.84329 -14.5743,0 l -39.3008,28.9375 c -0.6489,0.47782 -2.3674,-0.97736 -2.1444,-1.67578 l 14.9374,-46.77344 c 1.3128,-4.11079 -0.2669,-10.58816 -3.7226,-13.13284 l -39.754,-29.27344 c -1.6924,-1.30068 -1.4018,-3.3135 0.5704,-3.30082 h 48.586 c 4.2464,-0.44999 9.7338,-3.29965 11.1172,-7.26562 l 15.8984,-47.9023364 c 0.064,-0.1866 0.118,-0.3756 0.168,-0.56642 0.052,-0.20818 0.5508,-0.58294 0.91,-0.83594 z"
+         id="path5717-0-9-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsccccccsccccccccccccccccccccccccccsccssssccsssscccccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 5702.126,-175.39443 0.02,-0.0723 -1.4902,4.48243 h -4.6504 c -0.6202,0 -1.1339,0.29559 -1.4922,0.73046 -0.7959,0.91835 -0.6322,2.25491 0.375,2.93946 l -0.029,-0.0195 3.752,2.7539 -1.4453,4.50782 c 0,0.01 -0.01,0.0195 -0.01,0.0293 -0.2464,0.86305 0.2006,1.64798 0.7656,2.07227 0.565,0.42429 1.4436,0.63516 2.2031,0.15625 0.02,-0.013 0.04,-0.0266 0.059,-0.041 l 3.8184,-2.80273 3.8184,2.80273 c 0.015,0.0108 0.03,0.0212 0.045,0.0312 0.7713,0.50513 1.7273,0.42709 2.4101,-0.18359 0,-0.003 0.01,-0.007 0.014,-0.01 0.5683,-0.52542 0.7809,-1.29324 0.5547,-2.03906 0,-0.005 -0.01,-0.0104 -0.01,-0.0156 l -1.4433,-4.50782 3.7187,-2.73242 c 1.0089,-0.68352 1.1716,-2.02204 0.3789,-2.93945 -0.3674,-0.44717 -0.8841,-0.7138 -1.4609,-0.73242 -0.01,-1.6e-4 -0.021,-1.6e-4 -0.031,0 h -4.7343 l -1.3907,-4.42188 c -0.094,-0.35824 -0.2866,-0.67041 -0.5546,-0.92383 -1.6271,-0.77006 -2.0804,-0.69724 -3.191,0.93578 z m 1.874,0.69522 1.5196,4.82813 c 0.01,0.0224 0.015,0.0445 0.023,0.0664 0,0 0.1364,0.30397 0.3594,0.49219 0.223,0.18822 0.5819,0.32813 0.9394,0.32813 h 5.1172 c 0.01,0.008 0.014,0.0157 0.021,0.0234 -0.01,0.005 -0.013,0.0103 -0.02,0.0156 l -4.1445,3.04297 c -0.1079,0.0788 -0.1989,0.17842 -0.2676,0.29297 v 0.002 c -0.027,0.0291 -0.01,0.003 -0.053,0.0586 -0.124,0.1621 -0.2493,0.49216 -0.2363,0.75781 0.013,0.26566 0.097,0.44876 0.1796,0.60547 l -0.068,-0.16406 1.541,4.81445 -4.0508,-2.9746 c -0.012,-0.008 -0.023,-0.0159 -0.035,-0.0234 0,0 -0.2057,-0.14681 -0.5,-0.21875 -0.2943,-0.0719 -0.8543,-0.056 -1.2559,0.30469 l 0.076,-0.0625 -4.0332,2.96093 c -0.013,-0.007 -0.01,-0.0175 -0.031,0.0566 l 0.014,-0.043 -0.018,0.0137 c 0.018,-0.006 0.015,-0.0176 0.02,-0.0195 l 1.541,-4.80859 -0.1211,0.25 c 0.1288,-0.19319 0.2381,-0.43838 0.25,-0.72656 0.012,-0.28818 -0.099,-0.58545 -0.2364,-0.77149 -0.2745,-0.37206 -0.623,-0.45117 -0.623,-0.45117 l 0.2812,0.14453 -4.1445,-3.04296 c -0.01,-0.005 -0.013,-0.009 -0.02,-0.0137 0.01,-0.008 0.014,-0.0155 0.02,-0.0234 h 5.0274 c 0.7427,2.4e-4 1.2207,-0.66602 1.2207,-0.66602 0.04,-0.0645 0.072,-0.13331 0.096,-0.20508 z"
+         id="path5717-0-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsccccccscccccccccccccccccccccsscccccccccccccccccccccccccccccccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+         d="m 5691.9696,-49.707009 c -0,6.33e-4 -0.01,0.0013 -0.01,0.002 -0.5047,0.106246 -0.6803,0.464766 -0.8183,0.71484 l -0.6639,1.99605 h -2.1093 c -0.2985,0 -0.5429,0.14348 -0.7149,0.35156 -0.3829,0.44221 -0.3052,1.08044 0.1797,1.41016 l -0.016,-0.01 1.7031,1.25 -0.6562,2.04297 c -1e-4,0.0052 -1e-4,0.0104 0,0.0156 -0.1188,0.41617 0.095,0.79337 0.3652,0.996089 0.27,0.20273 0.6923,0.30508 1.0586,0.0742 0.01,-0.0068 0.02,-0.01399 0.029,-0.0215 l 1.7324,-1.271479 1.7324,1.271479 c 0.01,0.0054 0.014,0.01058 0.021,0.0156 0.3712,0.24333 0.8296,0.2058 1.1582,-0.0879 0,-0.002 0.01,-0.004 0.01,-0.006 0.2728,-0.252569 0.3743,-0.619689 0.2656,-0.978509 0,-0.0027 0,-0.0053 0,-0.008 l -0.6562,-2.04297 1.7031,-1.25 -0.016,0.01 c 0.4862,-0.32933 0.5624,-0.96848 0.1797,-1.41016 -0.1765,-0.21343 -0.423,-0.34264 -0.6992,-0.35156 -0.01,-8.5e-5 -0.011,-8.5e-5 -0.016,0 h -2.1484 l -0.6348,-2.02344 v 0.0176 c -0.2173,-0.506681 -0.3514,-0.707167 -0.9258,-0.70703 v 0 h -0.012 c -0.01,4.23e-4 -0.018,0.0011 -0.027,0.002 v -0.002 z m 0.074,1.17383 0.6622,2.10351 c 0,0.0112 0.01,0.02228 0.012,0.0332 0,0 0.066,0.14982 0.1758,0.242189 0.1093,0.0924 0.2861,0.160161 0.4589,0.160161 h 2.2559 l -1.832,1.3457 c -0.05,0.0372 -0.094,0.08358 -0.127,0.13672 -0.014,0.0144 -0.01,0.002 -0.029,0.0332 -0.011,0.0141 -0.01,0.0477 -0.02,0.0664 -0.049,0.0876 -0.103,0.20051 -0.098,0.30859 0.01,0.1312 0.048,0.2199 0.088,0.29493 l -0.035,-0.082 0.6718,2.0957 -1.7636,-1.29492 c -0.01,-0.004 -0.012,-0.0079 -0.018,-0.0117 0,0 -0.099,-0.0705 -0.2422,-0.10547 -0.143,-0.035 -0.4171,-0.0277 -0.6133,0.14844 l 0.037,-0.0312 -1.7617,1.29492 0.6699,-2.0957 -0.059,0.12304 c 0.062,-0.0934 0.1137,-0.21183 0.1192,-0.35351 0.01,-0.14169 -0.048,-0.28759 -0.1153,-0.37891 -0.1351,-0.18265 -0.3066,-0.22266 -0.3066,-0.22266 l 0.1406,0.0723 -1.832,-1.34375 h 2.2148 c 0.3598,-10e-4 0.5957,-0.32617 0.5957,-0.32617 0.019,-0.03199 0.035,-0.06605 0.047,-0.10156 z m 2.2286,6.88086 v 0.01 -0.008 c -5e-4,-10e-4 3e-4,-7.3e-4 0,-0.002 z"
+         id="path5862"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccscccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+         d="m 5687.9859,-6.285368 c -0.011,3.028e-4 -0.022,9.698e-4 -0.033,0.002 -0.3564,-0.00336 -0.6972,0.4142998 -0.7551,0.62696 l -0.5547,1.66407 h -1.7246 c -0.2782,0 -0.5047,0.13175 -0.664,0.32422 -0.3553,0.41088 -0.2844,0.99481 0.164,1.30273 0,9.2e-4 6e-4,0.003 0,0.004 l 1.3769,1.01172 -0.5351,1.67383 c -1e-4,0.0052 -1e-4,0.0104 0,0.0156 -0.1117,0.38911 0.088,0.73783 0.3359,0.92383 0.2478,0.186 0.64,0.28226 0.9824,0.0664 0.01,-0.00616 0.02,-0.012664 0.029,-0.0195 l 1.4154,-1.04101 1.418,1.04102 c 0.01,0.00476 0.015,0.00932 0.022,0.0137 0.3454,0.22626 0.7665,0.19299 1.0722,-0.0801 0,-0.00196 0.01,-0.00396 0.01,-0.006 0.2536,-0.23468 0.3473,-0.57264 0.2461,-0.90625 0,-0.00267 0,-0.00533 0,-0.008 l -0.5351,-1.67383 1.375,-1.01172 c 0.453,-0.3068 0.5241,-0.89499 0.1679,-1.30664 -0.1631,-0.19636 -0.3895,-0.31592 -0.6465,-0.32422 -0.01,-9.63e-5 -0.011,-9.63e-5 -0.017,0 h -1.7559 l -0.5156,-1.63476 c -0.1822,-0.4620345 -0.3963,-0.6681049 -0.8535,-0.6582 0,-3.33e-5 -0.01,-3.33e-5 -0.01,0 z m 0.033,1.32422 0.4863,1.54688 c 0,0.011204 0.01,0.022278 0.012,0.0332 0,0 0.066,0.14529 0.1719,0.23438 0.1054,0.0891 0.2752,0.15429 0.4375,0.15429 h 1.6699 l -1.3574,0.9961 c -0.051,0.037593 -0.095,0.08466 -0.1289,0.13867 0,0.00262 -0.01,0.00529 -0.01,0.008 -0.01,0.0105 0,-7.2e-4 -0.014,0.0137 -0.01,0.007 0,0.0235 -0.01,0.0312 -0.016,0.034992 -0.028,0.07169 -0.035,0.10937 8e-4,-0.004 0,-0.004 0,-0.008 -0.033,0.0791 -0.077,0.15438 -0.072,0.23633 0.01,0.12805 0.045,0.21198 0.082,0.28125 l -0.035,-0.084 0.4961,1.54297 -1.2989,-0.95117 c -0.01,-0.004017 -0.011,-0.007917 -0.017,-0.0117 0,0 -0.093,-0.0685 -0.2286,-0.10157 -0.1354,-0.0331 -0.4016,-0.0248 -0.5898,0.14454 l 0.039,-0.0312 -1.2969,0.95117 0.4941,-1.54297 -0.06,0.12695 c 0.058,-0.087 0.1094,-0.20212 0.1152,-0.33984 0.01,-0.13772 -0.047,-0.28178 -0.1133,-0.3711 -0.1316,-0.17864 -0.2968,-0.21484 -0.2968,-0.21484 l 0.1406,0.0723 -1.3574,-0.9961 h 1.6347 c 0.3432,5.6e-4 0.5703,-0.3125 0.5703,-0.3125 0.019,-0.031988 0.035,-0.066055 0.047,-0.10156 z m 2.0664,3.73242 c -0.045,0.0582 -0.056,0.0618 -0.018,0.0234 0,-0.003 0.01,-0.0163 0.01,-0.0195 z m -0.2559,1.84766 v 0.01 -0.006 c -5e-4,-0.002 5e-4,-0.002 0,-0.004 z"
+         id="path5879"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccccccccc" />
+      <g
+         transform="translate(-0.35202,1.138462)"
+         style="display:inline;fill:#b5835a;enable-background:new;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path5717-0-9-4">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new;font-variant-east_asian:normal;vector-effect:none"
+           d="m 5696.3419,-104.05741 c -0.02,7.1e-4 -0.041,0.002 -0.061,0.004 -1.2262,0.22534 -1.3404,0.96464 -1.4178,1.16793 l -0.9082,2.72852 h -2.8282 c -0.5247,0 -0.9465,0.245362 -1.2441,0.605455 -0.6686,0.775473 -0.5353,1.861768 0.3144,2.439453 l -0.029,-0.01953 2.2832,1.673828 -0.8789,2.746094 c 0,0.01036 -0.01,0.02078 -0.01,0.03125 -0.2092,0.733589 0.1678,1.38761 0.6269,1.732422 0.4592,0.344812 1.1961,0.526289 1.8418,0.119141 0.02,-0.01296 0.04,-0.02664 0.059,-0.04102 l 2.3203,-1.705078 2.3223,1.705078 c 0.015,0.01083 0.03,0.02125 0.045,0.03125 0.6488,0.424664 1.4298,0.36114 2.0039,-0.152344 0,-0.0032 0.01,-0.0065 0.014,-0.0098 0.4761,-0.440335 0.6504,-1.069752 0.4609,-1.695313 0,-0.0052 -0.01,-0.01045 -0.01,-0.01563 l -0.8789,-2.746094 2.25,-1.652343 c 0.8511,-0.576734 0.9823,-1.664999 0.3164,-2.439454 -0.3074,-0.371957 -0.7284,-0.589905 -1.209,-0.605455 -0.011,-8.5e-4 -0.022,-0.002 -0.033,-0.002 h -2.8789 l -0.8379,-2.66406 c -0.2993,-0.86196 -0.9051,-0.93677 -1.6074,-1.23633 v 0 h -0.02 z m 0.051,2.88281 0.6894,2.195301 c 0.081,0.257137 0.263,0.47054 0.5039,0.591797 0.089,0.04514 0.2422,0.123047 0.2422,0.123047 0.1399,0.07067 0.2945,0.107466 0.4512,0.107422 h 2.3828 l -1.9395,1.423828 c -0.1967,0.144914 -0.3335,0.356813 -0.3847,0.595703 0.057,-0.264948 0.045,-0.153446 -0.02,0.002 -0.032,0.0777 -0.1085,0.172069 -0.098,0.494141 0,0.09285 0.087,0.2329 0.1367,0.361328 l -0.055,-0.04883 0.6992,2.183593 -1.832,-1.345703 c -0.1714,-0.126473 -0.3788,-0.1949 -0.5918,-0.195312 h -0.3496 c -0.213,4.12e-4 -0.4204,0.06884 -0.5918,0.195312 l -1.834,1.345703 0.6992,-2.185547 c 0.052,-0.162118 0.062,-0.334896 0.029,-0.501953 l -0.061,-0.292968 c -0.05,-0.243767 -0.1881,-0.460333 -0.3887,-0.607422 l -1.9375,-1.423828 h 2.3203 c 0.1574,3.59e-4 0.3127,-0.03645 0.4532,-0.107422 0.093,-0.04715 0.2402,-0.121094 0.2402,-0.121094 0.2359,-0.119321 0.4149,-0.327175 0.498,-0.578125 l 0.7364,-2.210921 z"
+           id="path8858"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccscccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+      </g>
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:user-home"
+     id="g8102">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g8016"
+       inkscape:groupmode="layer">
+      <g
+         transform="translate(5760,0)"
+         style="display:inline;enable-background:new"
+         id="g10271">
+        <rect
+           inkscape:label="512x512"
+           y="-228"
+           x="16"
+           height="512"
+           width="512"
+           id="rect9831"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           id="path9833"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect7994"
+         width="48"
+         height="48"
+         x="6320"
+         y="-196"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-116"
+         x="6320"
+         height="32"
+         width="32"
+         id="rect7996"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect7998"
+         width="22"
+         height="22"
+         x="6321"
+         y="-58.941162"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-12"
+         x="6320"
+         height="16"
+         width="16"
+         id="rect8000"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-60"
+         x="6320"
+         height="24"
+         width="24"
+         id="rect8002"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text8006"
+         y="-279.63733"
+         x="5806.9438"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.63733"
+           x="5806.9438"
+           id="tspan8004"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="5886.3525"
+         y="-279.83838"
+         id="text8010"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           id="tspan8008"
+           x="5886.3525"
+           y="-279.83838"
+           style="font-size:14.66666698px;line-height:1.25">user-home</tspan></text>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g8100"
+       inkscape:groupmode="layer">
+      <use
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1"
+         x="0"
+         y="0"
+         xlink:href="#g11603"
+         id="use5372"
+         transform="translate(5759.9999)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="symbols"
+       style="display:inline">
+      <g
+         inkscape:label="user-home"
+         id="g8926"
+         style="display:inline;stroke-width:16.91082382;enable-background:new;fill:#b5835a;fill-opacity:1"
+         transform="matrix(0.59130837,0,0,0.59130837,5582.8166,333.72399)" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="M 6330.9961,-99.013672 A 1.0001,1.0001 0 0 0 6330.0117,-98 v 7 a 1.0001,1.0001 0 0 0 1,1 h 10 a 1.0001,1.0001 0 0 0 1,-1 v -7 a 1.0001,1.0001 0 1 0 -2,0 v 6 h -8 v -6 a 1.0001,1.0001 0 0 0 -1.0156,-1.013672 z"
+         id="path5414-5"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="m 6336.0195,-103 a 1.0001,1.0001 0 0 0 -0.6015,0.18555 l -7,4.999997 a 1.0010283,1.0010283 0 1 0 1.164,1.628906 l 6.418,-4.585933 6.418,4.585933 a 1.0010283,1.0010283 0 1 0 1.164,-1.628906 l -7,-4.999997 A 1.0001,1.0001 0 0 0 6336.0195,-103 Z"
+         id="path6184-3"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect6261-5"
+         width="3.031256"
+         height="4.9899402"
+         x="6334"
+         y="-95.989929" />
+      <rect
+         y="-97"
+         x="6343"
+         height="1"
+         width="1"
+         id="rect8452-7-6"
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-97"
+         x="6328"
+         height="1"
+         width="1"
+         id="rect8452-8-2"
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="M 6336.9961,-169.01367 A 1.0001,1.0001 0 0 0 6336.0117,-168 v 9 a 1.0001,1.0001 0 0 0 1,1 h 14 a 1.0001,1.0001 0 0 0 1,-1 v -9 a 1.0001,1.0001 0 1 0 -2,0 v 8 h -12 v -8 a 1.0001,1.0001 0 0 0 -1.0156,-1.01367 z"
+         id="path1579"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="m 6343.9883,-174 a 1.0001,1.0001 0 0 0 -0.543,0.16797 l -9,6 a 1.0001,1.0001 0 1 0 1.1094,1.66406 l 8.4453,-5.63086 8.4453,5.63086 a 1.0001,1.0001 0 1 0 1.1094,-1.66406 l -9,-6 A 1.0001,1.0001 0 0 0 6343.9883,-174 Z"
+         id="path1581"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="-165"
+         x="6341"
+         height="6"
+         width="3.9999526"
+         id="rect1583"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1585"
+         width="1"
+         height="1"
+         x="6353"
+         y="-167" />
+      <rect
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1587"
+         width="1"
+         height="1"
+         x="6334"
+         y="-167" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="M 6328.4922,-46.507812 A 0.50005066,0.50005066 0 0 0 6328,-46 v 4.5 a 0.50005066,0.50005066 0 0 0 0.5,0.5 h 7 a 0.50005066,0.50005066 0 0 0 0.5,-0.5 V -46 a 0.50005066,0.50005066 0 1 0 -1,0 v 4 h -6 v -4 a 0.50005066,0.50005066 0 0 0 -0.5078,-0.507812 z"
+         id="path1593"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="m 6331.9883,-49 a 0.50005066,0.50005066 0 0 0 -0.2715,0.08398 l -4.5,3 a 0.50005066,0.50005066 0 1 0 0.5547,0.832032 l 4.2226,-2.814454 4.2227,2.814454 a 0.50005066,0.50005066 0 1 0 0.5547,-0.832032 l -4.5,-3 A 0.50005066,0.50005066 0 0 0 6331.9883,-49 Z"
+         id="path1595"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1597"
+         width="1.9999788"
+         height="3.0000038"
+         x="6329.9941"
+         y="-44.500008" />
+      <rect
+         y="-45.500008"
+         x="6336.4941"
+         height="0.50000066"
+         width="0.50000066"
+         id="rect1599"
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-45.500008"
+         x="6326.9941"
+         height="0.50000066"
+         width="0.50000066"
+         id="rect1601"
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal"
+         d="M 6325.4922,-3.5078125 A 0.50005,0.50005 0 0 0 6325,-3 v 3.5 a 0.50005,0.50005 0 0 0 0.5,0.5 h 5 A 0.50005,0.50005 0 0 0 6331,0.5 V -3 a 0.50005,0.50005 0 1 0 -1,0 v 3 h -4 v -3 a 0.50005,0.50005 0 0 0 -0.5078,-0.5078125 z"
+         id="path1605"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 6328.0039,-5.5 a 0.50005,0.50005 0 0 0 -0.3008,0.09375 l -3.5,2.5 a 0.50005,0.50005 0 1 0 0.5821,0.8125 l 3.2089,-2.291016 3.209,2.291016 a 0.50005,0.50005 0 1 0 0.5821,-0.8125 l -3.5,-2.5 A 0.50005,0.50005 0 0 0 6328.0039,-5.5 Z"
+         id="path1607"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="-1.9949646"
+         x="6326.9941"
+         height="2.4949701"
+         width="1.515628"
+         id="rect1609"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1611"
+         width="0.5"
+         height="0.5"
+         x="6331.4941"
+         y="-2.5" />
+      <rect
+         style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1613"
+         width="0.5"
+         height="0.5"
+         x="6323.9941"
+         y="-2.5" />
+      <g
+         id="g1958"
+         style="opacity:0.8;fill:#b5835a">
+        <path
+           inkscape:connector-curvature="0"
+           id="path6184"
+           d="M 6031.7324,4.0039062 A 8.0008,8.0008 0 0 0 6027.7051,5.25 l -88,56 a 8.0008,8.0008 0 1 0 8.5898,13.5 L 6032,21.482422 6115.7051,74.75 a 8.0008,8.0008 0 1 0 8.5898,-13.5 l -88,-56 a 8.0008,8.0008 0 0 0 -4.5625,-1.2460938 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path5414"
+           d="M 5960.0156,53.886719 A 8.0008,8.0008 0 0 0 5952.1367,62 v 86 a 8.0008,8.0008 0 0 0 8,8 h 144.0645 a 8.0008,8.0008 0 0 0 8,-8 V 62 a 8.0008,8.0008 0 1 0 -16,0 v 78 H 5968.1367 V 62 a 8.0008,8.0008 0 0 0 -8.1211,-8.113281 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal" />
+        <rect
+           y="91.999634"
+           x="6000.0005"
+           height="56.000366"
+           width="31.999512"
+           id="rect6261"
+           style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect8452-7"
+           width="8"
+           height="8"
+           x="6120.0947"
+           y="67.999268" />
+        <rect
+           style="display:inline;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect8452-8"
+           width="8"
+           height="8"
+           x="5935.9995"
+           y="67.999268" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g6495"
+     inkscape:label="artwork:user-desktop"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g6463"
+       inkscape:label="baseplate"
+       style="display:none">
+      <g
+         id="g6443"
+         style="display:inline;enable-background:new"
+         transform="translate(6400,0)">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect6439"
+           width="512"
+           height="512"
+           x="16"
+           y="-228"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6441"
+           d="m 16,-228 0,512 512,0 0,-512 -36.00879,0 0,476 -439.982419,0 0,-476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+      <rect
+         inkscape:label="48x48"
+         y="-196"
+         x="6960"
+         height="48"
+         width="48"
+         id="rect6445"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6447"
+         width="32"
+         height="32"
+         x="6960"
+         y="-116"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-58.941162"
+         x="6961"
+         height="22"
+         width="22"
+         id="rect6449"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6451"
+         width="16"
+         height="16"
+         x="6960"
+         y="-12"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6453"
+         width="24"
+         height="24"
+         x="6960"
+         y="-60"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="6446.9438"
+         y="-279.63733"
+         id="text6457"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan6455"
+           x="6446.9438"
+           y="-279.63733"
+           style="font-size:14.66666698px;line-height:18.33333397">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text6461"
+         y="-279.83838"
+         x="6526.3525"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-279.83838"
+           x="6526.3525"
+           id="tspan6459"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:18.33333397">user-desktop</tspan></text>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g6467"
+       inkscape:label="icons"
+       style="display:inline">
+      <use
+         height="100%"
+         width="100%"
+         transform="translate(6399.9999)"
+         id="use6465"
+         xlink:href="#g11603"
+         y="0"
+         x="0"
+         style="display:inline;stroke:#a08f7f;stroke-opacity:1;enable-background:new;fill:#c9b8a7;fill-opacity:1" />
+    </g>
+    <g
+       inkscape:label="symbols"
+       id="g6493"
+       inkscape:groupmode="layer"
+       style="display:inline">
+      <path
+         id="path6636"
+         d="m 6974,-174 v 3 l 3,-3 z m 17,0 3,3 v -3 z m -10.998,3.0039 c -0.5514,-3.8e-4 -0.9984,0.44669 -0.998,0.99805 V -161 c -4e-4,0.55136 0.4466,0.99843 0.998,0.99805 l 6.998,-0.002 c 0.5514,3.8e-4 0.9984,-0.44669 0.998,-0.99805 v -6.49805 c -2e-4,-0.26457 -0.1056,-0.51821 -0.2929,-0.70508 l -2.5,-2.5 c -0.1869,-0.18732 -0.4405,-0.29271 -0.7051,-0.29297 z M 6981,-169 h 3 v 2 h 2 l 0,4.99995 -5.002,0.002 z m 13,8 -3,3 h 3 z m -20,0.0352 V -158 l 3,0.0352 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccc" />
+      <path
+         id="path10814"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 6632,12 c -4.4181,4.4e-4 -7.9996,5.5819 -8,10 l 4e-4,110 c 4e-4,4.4181 3.5819,7.99956 8,8 h 80.0272 c 4.4303,-4.1e-4 8.0169,-3.60096 8,-8.03126 l -0.1924,-86.6914 v 0.004 c 0,-2.05393 -0.7991,-4.02739 -2.2188,-5.51172 l -26.9218,-25.30468 c -1.5083,-1.57381 -3.5935,-2.46404 -5.7734,-2.46484 h -52.918 z m 8,16 h 44 v 20 h 20 v 76 h -64 l -4e-4,-96 z M 6576,-4 V 23.125 L 6603.1252,-4 Z M 6740.8748,-4 6768,23.125 V -4 Z M 6576,128.875 V 156 h 27.1252 z m 192,0 L 6740.8748,156 H 6768 Z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Abandoned Bitplane';-inkscape-font-specification:'Abandoned Bitplane';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 6969,-101 v 2.5293 c 0,0 2.5,-0.0293 2.5,-2.5293 z m 11.5,0 c 0,2.5 2.5,2.5293 2.5,2.5293 V -101 Z m -7.125,2 c -0.2388,0.0455 -0.4103,0.25655 -0.4062,0.5 v 6.03125 c 2e-4,0.27635 0.224,0.5002 0.5,0.5 h 4.0937 c 0.2636,-0.0164 0.4691,-0.23545 0.4687,-0.5 v -4.68751 c 3e-4,-0.0104 3e-4,-0.0208 0,-0.0312 0,-0.12628 -0.042,-0.24908 -0.125,-0.34376 l -1.3436,-1.31249 c -0.097,-0.10292 -0.2336,-0.1597 -0.375,-0.15625 h -2.7188 c -0.01,-3.2e-4 -0.021,-3.2e-4 -0.031,0 -0.021,-0.001 -0.042,-0.001 -0.062,0 z m 0.625,1 h 2 l 0.016,0.999995 L 6977,-97 v 4 h -3 z m -5,4.4707 V -91 h 2.5 c 0,-2.5 -2.5,-2.5293 -2.5,-2.5293 z m 14,0 c 0,0 -2.5,0.0293 -2.5,2.5293 h 2.5 z"
+         id="path10861"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none"
+         d="m 6967,-48 v 2 c 2,0 2,-2 2,-2 z m 8,0 c 0,0 0,2 2,2 v -2 z m -4.5508,0.99805 c -0.014,5e-5 -0.029,6.7e-4 -0.043,0.002 -0.239,0.0456 -0.4105,0.25667 -0.4062,0.5 v 4 c 0,0.27613 0.2239,0.49997 0.5,0.5 h 2.9688 c 0.2761,-3e-5 0.4999,-0.22387 0.5,-0.5 v -2.53125 c 0.01,-0.0415 0.01,-0.0835 0,-0.125 0,-0.12626 -0.041,-0.24906 -0.125,-0.34375 l -1.2188,-1.34375 c -0.097,-0.1028 -0.2335,-0.15958 -0.375,-0.15625 h -1.75 c -0.017,-0.001 -0.034,-0.002 -0.051,-0.002 z M 6971,-46 h 1.0312 l 0.9376,1.0625 V -43 H 6971 Z m -4,3 v 2 h 2 c 0,0 0,-2 -2,-2 z m 10,0 c -2,0 -2,2 -2,2 h 2 z"
+         id="path5066"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccsccccccccccccccccccccccccc" />
+      <path
+         id="path6772"
+         d="m 6963,-5 v 2 c 2,0 2,-2 2,-2 z m 8,0 c 0,0 0,2 2,2 v -2 z m -4.5508,0.99805 c -0.014,5e-5 -0.029,6.7e-4 -0.043,0.002 -0.239,0.0456 -0.4105,0.25667 -0.4062,0.5 v 4 c 0,0.27613 0.2239,0.49997 0.5,0.5 h 2.9688 c 0.2761,-3e-5 0.4999,-0.22387 0.5,-0.5 V -2.0312 c 0.01,-0.0415 0.01,-0.0835 0,-0.125 0,-0.12626 -0.041,-0.24906 -0.125,-0.34375 l -1.2188,-1.34375 c -0.097,-0.1028 -0.2335,-0.15958 -0.375,-0.15625 h -1.75 c -0.017,-10e-4 -0.034,-0.002 -0.051,-0.002 z M 6967,-3 h 1.0312 l 0.9376,1.0625 V 0 H 6967 Z m -4,3 v 2 h 2 c 0,0 0,-2 -2,-2 z m 10,0 c -2,0 -2,2 -2,2 h 2 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#b9a593;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccsccccccccccccccccccccccccc" />
+    </g>
+  </g>
+  <g
+     id="g7034"
+     inkscape:label="artwork:folder-remote"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g6948"
+       inkscape:label="baseplate"
+       style="display:none">
+      <g
+         id="g6928"
+         transform="translate(690,-517)">
+        <rect
+           inkscape:label="512x512"
+           y="-303"
+           x="-34"
+           height="512"
+           width="512"
+           id="rect6924"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="M -34,-303 V 209 H 478 V -303 H 441.99121 V 173 H 2.0087912 v -476 z"
+           id="path6926"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         inkscape:label="48x48"
+         y="-788"
+         x="1200"
+         height="48"
+         width="48"
+         id="rect6930"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6932"
+         width="32"
+         height="32"
+         x="1200"
+         y="-708"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-650.94116"
+         x="1201"
+         height="22"
+         width="22"
+         id="rect6934"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6936"
+         width="16"
+         height="16"
+         x="1200"
+         y="-604"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6938"
+         width="24"
+         height="24"
+         x="1200"
+         y="-652"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="663.85596"
+         y="-863.69958"
+         id="text6942"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan6940"
+           x="663.85596"
+           y="-863.69958"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text6946"
+         y="-863.90063"
+         x="743.26477"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-863.90063"
+           x="743.26477"
+           id="tspan6944"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">folder-remote</tspan></text>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g7032"
+       inkscape:label="icons"
+       style="display:inline">
+      <rect
+         style="opacity:1;fill:#77767b;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1668"
+         width="128"
+         height="32"
+         x="356"
+         y="-928"
+         transform="matrix(0,-1,-1,0,0,0)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1709"
+         d="m 896,-482 v 96 h -38.40039 c -5.3184,0 -9.59961,4.28121 -9.59961,9.59961 V -370 H 672 v 16 h 176 v 6.40039 c 0,5.3184 4.28121,9.59961 9.59961,9.59961 h 108.80078 c 5.3184,0 9.59961,-4.28121 9.59961,-9.59961 V -354 h 176 v -16 H 976 v -6.40039 C 976,-381.71879 971.71879,-386 966.40039,-386 H 928 v -96 z"
+         style="opacity:0.1;fill:url(#linearGradient1695);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1705)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1384"
+         d="m 744,-786 c 0,0 -40,0 -40,40 l -0.0352,128 h 0.0332 L 703.9648,-417.9062 1080,-418 c 40,0 40,-40 40,-40 v -160 -48 -48 c 0,0 0,-40 -40,-40 H 880 l -32,-32 z"
+         style="display:inline;opacity:0.2;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;filter:url(#filter1306)"
+         sodipodi:nodetypes="ccccccccccsccc" />
+      <rect
+         style="opacity:1;fill:#c9b8a7;fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1640"
+         width="2"
+         height="3"
+         x="1207"
+         y="-593" />
+      <rect
+         y="-745.5"
+         x="1200.5"
+         height="3"
+         width="47"
+         id="rect1594"
+         style="opacity:1;fill:url(#linearGradient5106);fill-opacity:1;stroke:url(#linearGradient5118);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-1227.5"
+         x="742.5"
+         height="6"
+         width="16"
+         id="rect1592"
+         style="opacity:1;fill:#c9b8a7;fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0,-1,-1,0,0,0)" />
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 1208,-784.5 c 0,0 -3.5,-4e-5 -3.5,3.5 v 16.5 h 39 V -777 c 0,0 0,-3.31107 -3.5,-3.5 h -18.5 l -4,-4 z"
+         id="path2018"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscccsccc" />
+      <path
+         id="path2020"
+         d="m 1208,-773.5 c 0,0 -3.5,0 -3.5,3.5 v 20.5 h 34.5 c 0,0 4.5,0 4.5,-4.5 v -20 c 0,0 0,-3.5 -3.5,-3.5 h -16.5 l -4,4 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 1203,-603.5 c 0,0 -1.5019,-0.0312 -1.5019,1.46875 V -597.5 H 1214.5 v -2.5 c 0,-1.5 -1.5,-1.5 -1.5,-1.5 h -3.5 l -2,-2 z"
+         id="path2026"
+         sodipodi:nodetypes="csccscccc" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 1212.999,-600.5 c 0,0 1.501,-0.0307 1.501,1.46928 V -594 c 0,1.5 -1.5,1.5 -1.5,1.5 h -11.5 v 0 l -10e-4,-4.5 c 0,-1.5 1.5,-1.5 1.5,-1.5 h 3.5 l 2,-2 z"
+         id="path2030" />
+      <g
+         style="display:inline;enable-background:new"
+         id="g7405"
+         transform="translate(690.07504,-1156.8521)" />
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="M 848,-788 H 744 c 0,0 -40,0 -40,40 v 128 h 416 v -96 c 0,0 0,-40 -40,-40 H 880 Z"
+         id="path1390"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         transform="translate(656,-628)"
+         id="path1505-6"
+         d="m 256,-80 -32,32 H 88 c 0,0 -40,0 -40,40 v 264 h 376 c 40,0 40,-40 40,-40 V -40 c 0,-40 -40,-40 -40,-40 z"
+         style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter1529-3);enable-background:new"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         clip-path="url(#clipPath1509-7)" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 912,-708 -32,32 H 744 c 0,0 -40,0 -40,40 v 216 h 376 c 40,0 40,-40 40,-40 v -208 c 0,-40 -40,-40 -40,-40 z"
+         id="path1392" />
+      <path
+         style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 1120,-466 c 0,0 0,40 -40,40 l -375.99805,0.094 -0.004,6 L 1080,-420 c 40,0 40,-40 40,-40 z"
+         id="path1394"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient5030);fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1590"
+         width="16"
+         height="5"
+         x="1216.5"
+         y="-746.5"
+         ry="1" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient5164);fill-opacity:1.0;stroke:url(#linearGradient5168);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1612"
+         width="33"
+         height="2"
+         x="1199.5"
+         y="-680.5" />
+      <rect
+         transform="matrix(0,-1,-1,0,0,0)"
+         style="opacity:1;fill:#c9b8a7;fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1614"
+         width="16"
+         height="5"
+         x="678.5"
+         y="-1218.5" />
+      <rect
+         ry="1"
+         y="-681.5"
+         x="1210.5"
+         height="4"
+         width="11"
+         id="rect1616"
+         style="opacity:1;vector-effect:none;fill:url(#linearGradient5074);fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         rx="1" />
+      <path
+         id="path2022"
+         d="m 1206,-706.5 c 0,0 -2.5,0 -2.5,2.5 v 10.5 h 22.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -6 c 0,0 0,-2.5 -2.5,-2.5 h -11.5 l -2,-2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 1206,-699.5 c 0,0 -2.5,0 -2.5,2.5 v 12.5 h 22.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -12 c 0,0 0,-2.5 -2.5,-2.5 h -10.5 l -2,2 z"
+         id="path2032" />
+      <path
+         style="opacity:1;fill:url(#linearGradient5210);fill-opacity:1.0;stroke:url(#linearGradient5212);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         d="m 1200.5,-631.5 h 23 v 2 h -23 z"
+         id="rect1622" />
+      <rect
+         y="-1213.5"
+         x="629.5"
+         height="3"
+         width="13"
+         id="rect1624"
+         style="opacity:1;fill:#c9b8a7;fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         transform="matrix(0,-1,-1,0,0,0)" />
+      <rect
+         style="opacity:1;fill:#77767b;fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1626"
+         width="7"
+         height="2"
+         x="1208.5"
+         y="-631.5"
+         ry="0" />
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 1205.5,-650.5 c -2,0 -2,2 -2,2 v 10 h 17 v -8 c 0,0 -0.015,-1.75193 -2,-2 h -8 l -2,-2 z"
+         id="path2024"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccccsccs" />
+      <path
+         id="path2028"
+         d="m 1205.5,-644.5 c -2,0 -2,2 -2,2 v 8 h 14.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -7.5 c 0,0 0,-2 -2,-2 h -6.5 l -2,2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient5254);fill-opacity:1.0;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none"
+         id="rect1632"
+         width="16"
+         height="1"
+         x="1200"
+         y="-590" />
+      <rect
+         ry="0"
+         y="-590.5"
+         x="1205.5"
+         height="2"
+         width="5"
+         id="rect1638"
+         style="opacity:1;fill:#77767b;fill-opacity:1;stroke:#77767b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;font-variant-east_asian:normal;vector-effect:none" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient1660);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1658"
+         width="480"
+         height="16"
+         x="672"
+         y="-372" />
+      <rect
+         ry="9.6000004"
+         y="-388"
+         x="848"
+         height="48"
+         width="128"
+         id="rect1664"
+         style="opacity:1;fill:url(#linearGradient5022);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+         d="m 912,-708 -32,32 H 744 c 0,0 -40,0 -40,40 v 4 c 0,-40 40,-40 40,-40 h 137.59099 l 32,-32 H 1080 c 0,0 40,0 40,40 v -4 c 0,-40 -40,-40 -40,-40 z"
+         id="path1328-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsccccccscc" />
+    </g>
+  </g>
+  <g
+     id="g7021"
+     inkscape:label="artwork:folder-open"
+     inkscape:groupmode="layer"
+     style="display:inline"
+     transform="translate(0,852)">
+    <g
+       inkscape:groupmode="layer"
+       id="g6937"
+       inkscape:label="baseplate"
+       style="display:none">
+      <g
+         id="g6917"
+         transform="translate(1970,-517)">
+        <rect
+           inkscape:label="512x512"
+           y="-303"
+           x="-34"
+           height="512"
+           width="512"
+           id="rect6913"
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="M -34,-303 V 209 H 478 V -303 H 441.99121 V 173 H 2.0087912 v -476 z"
+           id="path6915"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         inkscape:label="48x48"
+         y="-788"
+         x="2480"
+         height="48"
+         width="48"
+         id="rect6919"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6921"
+         width="32"
+         height="32"
+         x="2480"
+         y="-708"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="22x22"
+         y="-650.94116"
+         x="2481"
+         height="22"
+         width="22"
+         id="rect6923"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6925"
+         width="16"
+         height="16"
+         x="2480"
+         y="-604"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect6927"
+         width="24"
+         height="24"
+         x="2480"
+         y="-652"
+         inkscape:label="24x24" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="1943.856"
+         y="-863.69958"
+         id="text6931"
+         inkscape:label="context"><tspan
+           sodipodi:role="line"
+           id="tspan6929"
+           x="1943.856"
+           y="-863.69958"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         inkscape:label="icon-name"
+         id="text6935"
+         y="-863.90063"
+         x="2023.2648"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-863.90063"
+           x="2023.2648"
+           id="tspan6933"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">folder-open</tspan></text>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g7019"
+       inkscape:label="icons"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1845"
+         d="m 2024.0547,-770.01562 c 0,0 -40,0 -40,40 v 143.30468 c -8.5017,5.56897 -16,15.37992 -16,32.69532 l 16,200 h 376 c 40,0 40,-40 40,-40 l 16,-192 c 0,-17.3154 -7.4983,-27.12635 -16,-32.69532 v -79.30468 c 0,0 0,-40 -40,-40 h -200 l -32,-32 z"
+         style="display:inline;opacity:0.2;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter1835);enable-background:new"
+         sodipodi:nodetypes="cscccsccccsccc" />
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2486.0542,-785.5164 c 0,0 -3.5,0 -3.5,3.5 v 18.5 h 43 v -14.5 c 0,0 0,-3.5 -3.5,-3.5 h -20.5 l -4,-4 z"
+         id="path1639"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscccsccc" />
+      <path
+         id="path1641"
+         d="m 2484.0542,-768.51641 c 0,0 -3.5,0 -3.5,3.5 l 2,22.5 h 38.5 c 0,0 4.5,0 4.5,-4.5 l 2,-22 c 0,0 0,-3.5 -3.5,-3.5 h -20.5 l -4,4 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <path
+         id="path1643"
+         d="m 2485.0542,-705.51641 c 0,0 -2.5,0 -2.5,2.5 v 16.5 h 24.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -11 c 0,0 0,-2.5 -2.5,-2.5 h -12.5 l -3,-3 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2483.5542,-650.5164 c -2,0 -2,2 -2,2 v 15 h 21 v -13 c 0,0 0,-2 -2,-2 h -10 l -2,-2 z"
+         id="path1645"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccccsccs" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2482.0542,-603.5164 c 0,0 -1.5019,-0.0312 -1.5019,1.46875 v 10.53125 h 15.0019 v -8.5 c 0,-1.5 -1.5,-1.5 -1.5,-1.5 h -5.5 l -2,-2 z"
+         id="path1647"
+         sodipodi:nodetypes="csccscccc" />
+      <path
+         id="path1649"
+         d="m 2483.5542,-641.51641 c -2,0 -2,2 -2,2 v 10 h 18.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -9.5 c 0,0 0,-2 -2,-2 h -8.5 l -2,2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2494.0532,-598.51641 c 0,0 1.501,-0.0307 1.501,1.46928 v 7.03072 c 0,1.5 -1.5,1.5 -1.5,1.5 h -13.5 v 0 -6.5 c 0,-1.5 1.5,-1.5 1.5,-1.5 h 3.5 l 2,-2 z"
+         id="path1651" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2484.0542,-693.51641 c 0,0 -2.5,0 -2.5,2.5 l 1,12.5 h 24.5 c 2.5,0 2.5,-2.5 2.5,-2.5 l 1,-12 c 0,0 0,-2.5 -2.5,-2.5 h -12.5 l -2,2 z"
+         id="path1653" />
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2128.0542,-772.0164 h -104 c 0,0 -40,0 -40,40 v 160 h 416 v -128 c 0,0 0,-40 -40,-40 h -200 z"
+         id="path1629"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2192.0542,-628.0164 -32,32 h -152 c 0,0 -40,0 -40,40 l 16,200 h 376 c 40,0 40,-40 40,-40 l 16,-192 c 0,-40 -40,-40 -40,-40 z"
+         id="path1631" />
+      <path
+         style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 2400.0547,-402.01562 c 0,0 0,40 -40,40 h -376 v 6 h 376 c 40,0 40,-40 40,-40 z"
+         id="path1817"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccscc" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="M 2192.0547 223.98438 L 2160.0547 255.98438 L 2008.0547 255.98438 C 2008.0547 255.98438 1968.0547 255.98438 1968.0547 295.98438 L 1968.1367 297.02344 C 1970.0643 259.99065 2008.0547 259.98438 2008.0547 259.98438 L 2160.0547 259.98438 L 2192.0547 227.98438 L 2376.0547 227.98438 C 2376.0547 227.98438 2414.0247 227.99054 2415.9707 264.99414 L 2416.0547 263.98438 C 2416.0547 223.98438 2376.0547 223.98438 2376.0547 223.98438 L 2192.0547 223.98438 z "
+         transform="translate(0,-852)"
+         id="path1358" />
+    </g>
+  </g>
+  <g
+     transform="translate(0,852)"
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="artwork:folder-drag-accept"
+     id="g7232">
+    <g
+       style="display:none"
+       inkscape:label="baseplate"
+       id="g7150"
+       inkscape:groupmode="layer">
+      <g
+         transform="translate(2610,-517)"
+         id="g7130">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           id="rect7126"
+           width="512"
+           height="512"
+           x="-34"
+           y="-303"
+           inkscape:label="512x512" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7128"
+           d="M -34,-303 V 209 H 478 V -303 H 441.99121 V 173 H 2.0087912 v -476 z"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect7132"
+         width="48"
+         height="48"
+         x="3120"
+         y="-788"
+         inkscape:label="48x48" />
+      <rect
+         inkscape:label="32x32"
+         y="-708"
+         x="3120"
+         height="32"
+         width="32"
+         id="rect7134"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect7136"
+         width="22"
+         height="22"
+         x="3121"
+         y="-650.94116"
+         inkscape:label="22x22" />
+      <rect
+         inkscape:label="16x16"
+         y="-604"
+         x="3120"
+         height="16"
+         width="16"
+         id="rect7138"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         inkscape:label="24x24"
+         y="-652"
+         x="3120"
+         height="24"
+         width="24"
+         id="rect7140"
+         style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <text
+         inkscape:label="context"
+         id="text7144"
+         y="-863.69958"
+         x="2583.856"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         xml:space="preserve"><tspan
+           y="-863.69958"
+           x="2583.856"
+           id="tspan7142"
+           sodipodi:role="line"
+           style="font-size:14.66666698px;line-height:1.25">places</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Cantarell;-inkscape-font-specification:'Cantarell, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="2663.2646"
+         y="-863.90063"
+         id="text7148"
+         inkscape:label="icon-name"><tspan
+           sodipodi:role="line"
+           id="tspan7146"
+           x="2663.2646"
+           y="-863.90063"
+           style="font-size:14.66666698px;line-height:1.25">folder-drag-accept</tspan></text>
+    </g>
+    <g
+       style="display:inline"
+       inkscape:label="icons"
+       id="g7230"
+       inkscape:groupmode="layer">
+      <path
+         sodipodi:nodetypes="cscccsccc"
+         inkscape:connector-curvature="0"
+         id="path1874"
+         d="m 3126.0542,-785.5164 c 0,0 -3.5,0 -3.5,3.5 v 26.5 h 43 v -22.5 c 0,0 0,-3.5 -3.5,-3.5 h -20.5 l -4,-4 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 3124.0542,-760.51641 c 0,0 -3.5,0 -3.5,3.5 l 2,14.5 h 38.5 c 0,0 4.5,0 4.5,-4.5 l 2,-14 c 0,0 0,-3.5 -3.5,-3.5 h -20.5 l -4,4 z"
+         id="path1876" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 3125.0542,-705.51641 c 0,0 -2.5,0 -2.5,2.5 v 20.5 h 24.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -15 c 0,0 0,-2.5 -2.5,-2.5 h -12.5 l -3,-3 z"
+         id="path1878" />
+      <path
+         sodipodi:nodetypes="sccccsccs"
+         inkscape:connector-curvature="0"
+         id="path1880"
+         d="m 3123.5542,-650.5164 c -2,0 -2,2 -2,2 v 15 h 21 v -13 c 0,0 0,-2 -2,-2 h -10 l -2,-2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal" />
+      <path
+         sodipodi:nodetypes="csccscccc"
+         id="path1882"
+         d="m 3122.0542,-603.5164 c 0,0 -1.5019,-0.0312 -1.5019,1.46875 v 10.53125 h 15.0019 v -8.5 c 0,-1.5 -1.5,-1.5 -1.5,-1.5 h -5.5 l -2,-2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:#a08f7f;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         d="m 3123.5542,-637.51641 c -2,0 -2,2 -2,2 v 6 h 18.5 c 2.5,0 2.5,-2.5 2.5,-2.5 v -5.5 c 0,0 0,-2 -2,-2 h -8.5 l -2,2 z"
+         id="path1884" />
+      <path
+         id="path1886"
+         d="m 3134.0532,-594.51641 c 0,0 1.501,-0.0307 1.501,1.46928 v 3.03072 c 0,1.5 -1.5,1.5 -1.5,1.5 h -13.5 v 0 -2.5 c 0,-1.5 1.5,-1.5 1.5,-1.5 h 3.5 l 2,-2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccc" />
+      <path
+         id="path1888"
+         d="m 3124.0542,-689.51641 c 0,0 -2.5,0 -2.5,2.5 l 1,8.5 h 24.5 c 2.5,0 2.5,-2.5 2.5,-2.5 l 1,-8 c 0,0 0,-2.5 -2.5,-2.5 h -12.5 l -2,2 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:#a08f7f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g1996">
+        <path
+           sodipodi:nodetypes="cscccsccccsccc"
+           inkscape:connector-curvature="0"
+           id="path1864"
+           d="m 2664.0547,-770.01562 c 0,0 -40,0 -40,40 v 207.30468 c -8.5017,5.56897 -16,15.37992 -16,32.69532 l 16,136 h 376 c 40,0 40,-40 40,-40 l 16,-128 c 0,-17.3154 -7.4983,-27.12635 -16,-32.69532 v -143.30468 c 0,0 0,-40 -40,-40 h -200 l -32,-32 z"
+           style="display:inline;opacity:0.2;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter1835);enable-background:new" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#c9b8a7;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+           d="m 2768.0542,-772.0164 h -104 c 0,0 -40,0 -40,40 v 224 h 416 v -192 c 0,0 0,-40 -40,-40 h -200 z"
+           id="path1872"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           style="display:inline;opacity:1;vector-effect:none;fill:#ded4ca;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+           d="m 2832.0542,-564.0164 -32,32 h -160 c 0,0 -32,0 -32,40 l 16,136 h 376 c 40,0 40,-40 40,-40 l 16,-128 c 0,-40 -32,-40 -32,-40 z"
+           id="path1890" />
+        <path
+           style="display:inline;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+           d="m 3040.0547,-402.01562 c 0,0 0,40 -40,40 h -376 v 6 h 376 c 40,0 40,-40 40,-40 z"
+           id="path1892"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csccscc" />
+        <path
+           style="display:inline;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:26.06693268;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new;font-variant-east_asian:normal"
+           d="M 2832.0547 287.98438 L 2800.0547 319.98438 L 2640.0547 319.98438 C 2640.0547 319.98438 2608.0547 319.98437 2608.0547 359.98438 L 2608.1387 360.69336 C 2609.8485 323.99357 2640.0547 323.98438 2640.0547 323.98438 L 2800.0547 323.98438 L 2832.0547 291.98438 L 3024.0547 291.98438 C 3024.0547 291.98437 3054.2418 291.99252 3055.9707 328.6543 L 3056.0547 327.98438 C 3056.0547 287.98438 3024.0547 287.98437 3024.0547 287.98438 L 2832.0547 287.98438 z "
+           transform="translate(0,-852)"
+           id="path1360" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/gen-color-folders.sh
+++ b/gen-color-folders.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+path="./src/fullcolor"
+
+if [ ! -d "$path" ]; then
+  mkdir $path -p
+fi
+
+# Adwaita Default
+maindefault="ded4ca"
+darkdefault="c9b8a7"
+symbdefault="b9a593"
+strkdefault="a08f7f"
+
+colorsList=(amber blue blueGrey brown cyan deepOrange deepPurple green grey indigo lightBlue lightGreen lime orange pink purple red rikka teal yellow)
+mainColors=(ffc107 2196f3 607d8b 795548 00bcd4 ff5722 673ab7 4caf50 9e9e9e 3f51b5 03a9f4 8bc34a cddc39 ff9800 e91e63 9c27b0 f44336 4f6479 009688 ffeb3b)
+darkColors=(ffa000 1976d2 455a64 5d4037 0097a7 e64a19 512da8 388e3c 616161 303f9f 0288d1 689f38 afb42b ef6c00 c2185b 7b1fa2 d32f2f 244b6f 00796b fbc02d)
+strkColors=(d69800 006dca 375462 502C1F 0093AB D62E00 3E118E 238627 757575 16288C 0080cb 629A21 A4B310 D66F00 C0003A 730087 CB1A0D 263B50 006D5F D6C212)
+
+for i in "${!colorsList[@]}"; do
+  cp folders.svg $path/folders-${colorsList[$i]}.svg
+  sed -i -e "s/$maindefault/${mainColors[$i]}/g" $path/folders-${colorsList[$i]}.svg
+  sed -i -e "s/$darkdefault/${darkColors[$i]}/g" $path/folders-${colorsList[$i]}.svg
+  sed -i -e "s/$symbdefault/${darkColors[$i]}/g" $path/folders-${colorsList[$i]}.svg
+  sed -i -e "s/$strkdefault/${strkColors[$i]}/g" $path/folders-${colorsList[$i]}.svg
+  sed -i -e "s/folder/folder-${colorsList[$i]}/g" $path/folders-${colorsList[$i]}.svg
+  sed -i -e "s/user/user-${colorsList[$i]}/g" $path/folders-${colorsList[$i]}.svg; done

--- a/render-icon-theme.py
+++ b/render-icon-theme.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import xml.sax
+import subprocess
+
+OPTIPNG = '/usr/bin/optipng'
+ZOPFLIPNG = '/usr/bin/zopflipng'
+SRC = os.path.join('.', 'src', 'fullcolor')
+
+inkscape_process = None
+
+def optimize_png(png_file):
+    if os.path.exists(ZOPFLIPNG):
+        process = subprocess.Popen([ZOPFLIPNG, '-y', '-m', png_file, png_file], stdout=open(os.devnull, 'wb'))
+        process.wait()
+    elif os.path.exists(OPTIPNG):
+        process = subprocess.Popen([OPTIPNG, '-quiet', '-o7', png_file], stdout=open(os.devnull, 'wb'))
+        process.wait()
+
+def wait_for_prompt(process, command=None):
+    if command is not None:
+        process.stdin.write((command+'\n').encode('utf-8'))
+
+    # This is kinda ugly ...
+    # Wait for just a '>', or '\n>' if some other char appearead first
+    output = process.stdout.read(1)
+    if output == b'>':
+        return
+
+    output += process.stdout.read(1)
+    while output != b'\n>':
+        output += process.stdout.read(1)
+        output = output[1:]
+
+def start_inkscape():
+    process = subprocess.Popen(['inkscape','--shell'], bufsize=0, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    wait_for_prompt(process)
+    return process
+
+def inkscape_render_rect(icon_file, rect, output_file):
+    global inkscape_process
+    if inkscape_process is None:
+        inkscape_process = start_inkscape()
+    wait_for_prompt(inkscape_process, '%s -i %s -e %s' % (icon_file, rect, output_file))
+    optimize_png(output_file)
+
+class ContentHandler(xml.sax.ContentHandler):
+    ROOT = 0
+    SVG = 1
+    LAYER = 2
+    OTHER = 3
+    TEXT = 4
+    def __init__(self, path, force=False, filter=None):
+        self.stack = [self.ROOT]
+        self.inside = [self.ROOT]
+        self.path = path
+        self.rects = []
+        self.state = self.ROOT
+        self.chars = ""
+        self.force = force
+        self.filter = filter
+
+    def endDocument(self):
+        pass
+
+    def startElement(self, name, attrs):
+        if self.inside[-1] == self.ROOT:
+            if name == "svg":
+                self.stack.append(self.SVG)
+                self.inside.append(self.SVG)
+                return
+        elif self.inside[-1] == self.SVG:
+            if (name == "g" and ('inkscape:groupmode' in attrs) and ('inkscape:label' in attrs)
+               and attrs['inkscape:groupmode'] == 'layer' and attrs['inkscape:label'].startswith('baseplate')):
+                self.stack.append(self.LAYER)
+                self.inside.append(self.LAYER)
+                self.context = None
+                self.icon_name = None
+                self.rects = []
+                return
+        elif self.inside[-1] == self.LAYER:
+            if name == "text" and ('inkscape:label' in attrs) and attrs['inkscape:label'] == 'context':
+                self.stack.append(self.TEXT)
+                self.inside.append(self.TEXT)
+                self.text='context'
+                self.chars = ""
+                return
+            elif name == "text" and ('inkscape:label' in attrs) and attrs['inkscape:label'] == 'icon-name':
+                self.stack.append(self.TEXT)
+                self.inside.append(self.TEXT)
+                self.text='icon-name'
+                self.chars = ""
+                return
+            elif name == "rect":
+                self.rects.append(attrs)
+
+        self.stack.append(self.OTHER)
+
+
+    def endElement(self, name):
+        stacked = self.stack.pop()
+        if self.inside[-1] == stacked:
+            self.inside.pop()
+
+        if stacked == self.TEXT and self.text is not None:
+            assert self.text in ['context', 'icon-name']
+            if self.text == 'context':
+                self.context = self.chars
+            elif self.text == 'icon-name':
+                self.icon_name = self.chars
+            self.text = None
+        elif stacked == self.LAYER:
+            assert self.icon_name
+            assert self.context
+
+            if self.filter is not None and not self.icon_name in self.filter:
+                return
+
+            print (self.context, self.icon_name)
+            for rect in self.rects:
+                width = rect['width']
+                height = rect['height']
+                id = rect['id']
+
+                dir = os.path.join("Adwaita", "%sx%s" % (width, height), self.context)
+                outfile = os.path.join(dir, self.icon_name+'.png')
+                if not os.path.exists(dir):
+                    os.makedirs(dir)
+                # Do a time based check!
+                if self.force or not os.path.exists(outfile):
+                    inkscape_render_rect(self.path, id, outfile)
+                    sys.stdout.write('.')
+                else:
+                    stat_in = os.stat(self.path)
+                    stat_out = os.stat(outfile)
+                    if stat_in.st_mtime > stat_out.st_mtime:
+                        inkscape_render_rect(self.path, id, outfile)
+                        sys.stdout.write('.')
+                    else:
+                        sys.stdout.write('-')
+                sys.stdout.flush()
+            sys.stdout.write('\n')
+            sys.stdout.flush()
+
+    def characters(self, chars):
+        self.chars += chars.strip()
+
+if len(sys.argv) == 1:
+    if not os.path.exists('Adwaita'):
+        os.mkdir('Adwaita')
+    print ('Rendering from SVGs in', SRC)
+    for file in os.listdir(SRC):
+        if file[-4:] == '.svg':
+            file = os.path.join(SRC, file)
+            handler = ContentHandler(file)
+            xml.sax.parse(open(file), handler)
+else:
+    file = os.path.join(SRC, sys.argv[1] + '.svg')
+    if len(sys.argv) > 2:
+        icons = sys.argv[2:]
+    else:
+        icons = None
+    if os.path.exists(os.path.join(file)):
+        handler = ContentHandler(file, True, filter=icons)
+        xml.sax.parse(open(file), handler)
+    else:
+        print ("Error: No such file", file)
+        sys.exit(1)


### PR DESCRIPTION
I used resources from https://github.com/GNOME/adwaita-icon-theme
1. adwaita-icon-theme/src/fullcolor/folders.svg
2. adwaita-icon-theme/render-icon-theme.py
And created a script to create modified versions of the original folders.svg with the 20 additional colors.
the render script can then be used to generate all icons or a single color set.

![Screenshot from 2020-04-29 21-29-46](https://user-images.githubusercontent.com/36554733/80638551-e44d8300-8a60-11ea-8e38-4f5145571cb8.png)
![Screenshot from 2020-04-29 21-30-02](https://user-images.githubusercontent.com/36554733/80638557-e57eb000-8a60-11ea-8f2b-793cb8bef7d1.png)
![Screenshot from 2020-04-29 21-30-16](https://user-images.githubusercontent.com/36554733/80638559-e57eb000-8a60-11ea-9acd-22c07238ab90.png)
![Screenshot from 2020-04-29 21-30-26](https://user-images.githubusercontent.com/36554733/80638560-e6174680-8a60-11ea-9cec-48ddafacdd3f.png)

I didn't dig deeper into understanding the python script, e.g to avoid generating useless files. It is possible to make it generate svg files, but those are heavy because each icon contains the entire template, only the document frame is resized around a single icon. 